### PR TITLE
feat: auto-detect RTL page order for manga EPUB and CBZ/CBR

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ For EPUBs that do not include this CSS, add the following via
 body { writing-mode: vertical-rl !important; }
 ```
 
+## RTL page order (漫画・右開き)
+
+Japanese manga EPUBs and CBZ/CBR files with right-to-left page order are detected
+automatically when you open them for the first time:
+
+- **EPUB**: reads `page-progression-direction="rtl"` from the OPF spine
+- **CBZ/CBR**: reads `<ReadingDirection>RTL</ReadingDirection>` from `ComicInfo.xml`
+
+When RTL is detected a notification appears, the page-turn direction is reversed,
+and the progress bar fills from right (page 1) to left (last page).
+
+You can always override the detected direction via
+**Menu → Taps & gestures → Page turns → Switch page-turn direction**.
+The override is saved per-book and will not be overwritten on subsequent opens.
+
 ## Known limitations
 
 - **Mixed horizontal/vertical layouts are not supported.** A single document renders

--- a/frontend/apps/reader/modules/reader_auto_direction.lua
+++ b/frontend/apps/reader/modules/reader_auto_direction.lua
@@ -1,0 +1,62 @@
+--[[--
+Auto-detects page progression direction (RTL/LTR) from document metadata and
+applies it to the reader view when the user has not made an explicit choice.
+
+Supported sources:
+- EPUB: `page-progression-direction` attribute on the OPF `<spine>` element
+  (stored in document props by crengine's epubfmt.cpp, exposed via cre.cpp)
+- CBZ/CBR/CBT: `<ReadingDirection>` element inside ComicInfo.xml
+
+This module is intentionally separate from ReaderView so that upstream
+merges to readerview.lua do not conflict with fork-specific detection logic.
+The module runs its onReadSettings *after* ReaderView (registered later), so
+view state set by ReaderView is already available.
+]]
+
+local BD = require("ui/bidi")
+local EventListener = require("ui/widget/eventlistener")
+local Notification = require("ui/widget/notification")
+local _ = require("gettext")
+
+local ReaderAutoDirection = EventListener:extend{}
+
+function ReaderAutoDirection:onReadSettings(config)
+    -- "direction_auto_detected" is written the first time we successfully detect
+    -- a direction for this document.  Once set, we defer entirely to whatever
+    -- inverse_reading_order the user (or the previous auto-run) left behind.
+    -- This avoids re-detecting on every open while still letting the user override.
+    if config:has("direction_auto_detected") then return end
+
+    -- Global RTL default already in effect – nothing to do.
+    if self.view.inverse_reading_order then return end
+
+    local ok, PageDirection = pcall(require, "util/page_direction")
+    if not ok then return end
+
+    local dir = PageDirection.getDirection(self.document)
+
+    -- Mark detection as done regardless of outcome so we don't re-scan on
+    -- every open (the result is stored in inverse_reading_order itself).
+    config:saveSetting("direction_auto_detected", dir or "none")
+
+    if dir ~= "rtl" then return end
+
+    -- Apply RTL reading order and keep the progress bar in sync.
+    -- ReaderView:onReadSettings ran first and set the bar for the non-detected
+    -- value; re-apply now to reflect the auto-detected reading order.
+    self.view.inverse_reading_order = not BD.mirroredUILayout()
+    self.view:setupTouchZones()
+    self:_syncProgressBar()
+    Notification:notify(_("RTL page order detected – switching automatically."))
+end
+
+-- Recompute and apply the combined progress-bar inversion.
+-- Called after auto-detection so the bar reflects the updated reading order.
+function ReaderAutoDirection:_syncProgressBar()
+    if not self.view.footer then return end
+    local is_rtl = self.view.inverse_reading_order ~= BD.mirroredUILayout()
+    local invert = self.view.invert_ui_layout or is_rtl
+    self.view.footer:invertProgressBar(invert)
+end
+
+return ReaderAutoDirection

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1020,7 +1020,10 @@ function ReaderView:onReadSettings(config)
     else
         self.invert_ui_layout = G_reader_settings:isTrue("invert_ui_layout")
     end
-    self.footer:invertProgressBar(self.invert_ui_layout)
+    -- Progress bar: invert when UI is mirrored, or when RTL reading order is active.
+    -- XOR with mirroredUILayout() ensures the two effects cancel in a mirrored-UI locale.
+    local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout()
+    self.footer:invertProgressBar(self.invert_ui_layout or is_rtl)
     self.page_overlap_enable = config:isTrue("show_overlap_enable") or G_reader_settings:isTrue("page_overlap_enable") or G_defaults:readSetting("DSHOWOVERLAP")
     self.page_overlap_style = config:readSetting("page_overlap_style") or G_reader_settings:readSetting("page_overlap_style") or "dim"
     self.page_gap.height = Screen:scaleBySize(config:readSetting("kopt_page_gap_height")
@@ -1038,7 +1041,8 @@ function ReaderView:onToggleUILayoutMiroring(toggle)
     end
     if self.invert_ui_layout ~= toggle then
         self.invert_ui_layout = toggle
-        self.footer:invertProgressBar(self.invert_ui_layout)
+        local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout()
+        self.footer:invertProgressBar(self.invert_ui_layout or is_rtl)
     end
     return true
 end
@@ -1344,6 +1348,8 @@ function ReaderView:onToggleReadingOrder(toggle)
         self:setupTouchZones()
         local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
         Notification:notify(is_rtl and _("RTL page turning.") or _("LTR page turning."))
+        -- Keep progress bar direction in sync with reading order.
+        self.footer:invertProgressBar(self.invert_ui_layout or is_rtl)
     end
     return true
 end

--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
@@ -56,6 +56,7 @@ local ReaderToc = require("apps/reader/modules/readertoc")
 local ReaderTypeset = require("apps/reader/modules/readertypeset")
 local ReaderTypography = require("apps/reader/modules/readertypography")
 local ReaderUserHyph = require("apps/reader/modules/readeruserhyph")
+local ReaderAutoDirection = require("apps/reader/modules/reader_auto_direction")
 local ReaderView = require("apps/reader/modules/readerview")
 local ReaderWikipedia = require("apps/reader/modules/readerwikipedia")
 local ReaderZooming = require("apps/reader/modules/readerzooming")
@@ -450,6 +451,13 @@ function ReaderUI:init()
         document = self.document,
         view = self.view,
         ui = self,
+    })
+    -- Auto-detect RTL/LTR from document metadata (EPUB OPF / CBZ ComicInfo.xml).
+    -- Registered last so ReaderView's onReadSettings runs first.
+    self:registerModule("auto_direction", ReaderAutoDirection:new{
+        view = self.view,
+        ui = self,
+        document = self.document,
     })
 
     -- koreader plugins

--- a/frontend/util/page_direction.lua
+++ b/frontend/util/page_direction.lua
@@ -1,0 +1,133 @@
+--[[--
+Page progression direction detector for automatic RTL/LTR reading order.
+
+Supports:
+- EPUB: reads `page-progression-direction` from OPF spine directly via the
+  ZIP archive (bypasses crengine cache entirely — reliable on first open)
+- CBZ/CBR/CBT: reads `<ReadingDirection>` from ComicInfo.xml inside the archive
+
+Both formats are handled via ffi/archiver (libarchive), so no C++ changes
+are required and the detection is cache-independent.
+]]
+
+local logger = require("logger")
+local M = {}
+
+-- ── helpers ──────────────────────────────────────────────────────────────
+
+local function openArchiveReader(filepath)
+    local ok, Archiver = pcall(require, "ffi/archiver")
+    if not ok then return nil end
+    local reader = Archiver.Reader:new()
+    if not reader:open(filepath) then return nil end
+    return reader
+end
+
+-- ── ComicInfo.xml (CBZ/CBR) ──────────────────────────────────────────────
+
+local function parseComicInfo(xml)
+    if not xml then return nil end
+    local dir = xml:match("<ReadingDirection>%s*(%a+)%s*</ReadingDirection>")
+    return dir and (dir:upper() == "RTL" and "rtl" or "ltr") or nil
+end
+
+local function directionFromComicInfo(filepath)
+    local reader = openArchiveReader(filepath)
+    if not reader then return nil end
+    local direction
+    for entry in reader:iterate() do
+        if entry.mode == "file" then
+            local lp = entry.path:lower()
+            if lp == "comicinfo.xml" or lp:match("/comicinfo%.xml$") then
+                direction = parseComicInfo(reader:extractToMemory(entry.path))
+                break
+            end
+        end
+    end
+    reader:close()
+    return direction
+end
+
+-- ── EPUB OPF ─────────────────────────────────────────────────────────────
+
+-- Extract the OPF root-file path from META-INF/container.xml content.
+local function opfPathFromContainer(xml)
+    if not xml then return nil end
+    return xml:match('full%-path="([^"]+)"')
+end
+
+-- Extract page-progression-direction from OPF content.
+local function ppdFromOPF(xml)
+    if not xml then return nil end
+    -- Match the <spine> element (possibly with many attributes).
+    local spine = xml:match("<spine[^>]*>") or xml:match("<spine[^/]*/?>")
+    if not spine then return nil end
+    local ppd = spine:match('page%-progression%-direction="(%a+)"')
+    if not ppd then return nil end
+    ppd = ppd:lower()
+    return (ppd == "rtl" or ppd == "ltr") and ppd or nil
+end
+
+local function directionFromEpub(filepath)
+    local reader = openArchiveReader(filepath)
+    if not reader then return nil end
+
+    -- Step 1: find container.xml to locate the OPF.
+    local opf_path
+    for entry in reader:iterate() do
+        if entry.mode == "file" then
+            local lp = entry.path:lower()
+            if lp == "meta-inf/container.xml" then
+                local xml = reader:extractToMemory(entry.path)
+                opf_path = opfPathFromContainer(xml)
+                break
+            end
+        end
+    end
+    if not opf_path then
+        reader:close()
+        logger.dbg("PageDirection: no container.xml found in", filepath)
+        return nil
+    end
+
+    -- Step 2: read the OPF and extract page-progression-direction.
+    local direction
+    -- extractToMemory can seek; try by path key first.
+    local xml = reader:extractToMemory(opf_path)
+    if not xml then
+        -- Path lookup may be case-sensitive; scan all entries.
+        local lp_target = opf_path:lower()
+        for entry in reader:iterate() do
+            if entry.mode == "file" and entry.path:lower() == lp_target then
+                xml = reader:extractToMemory(entry.path)
+                break
+            end
+        end
+    end
+    direction = ppdFromOPF(xml)
+    reader:close()
+    logger.dbg("PageDirection: EPUB", filepath, "→", direction)
+    return direction
+end
+
+-- ── public API ───────────────────────────────────────────────────────────
+
+-- Return the page progression direction for a document file.
+-- @param document  A document instance (must expose .file path).
+-- @return "rtl", "ltr", or nil (direction unknown / not specified).
+function M.getDirection(document)
+    if not document or not document.file then return nil end
+    local ext = document.file:match("%.(%w+)$")
+    if not ext then return nil end
+    ext = ext:lower()
+
+    if ext == "epub" or ext == "epub3" then
+        return directionFromEpub(document.file)
+    elseif ext == "cbz" or ext == "cbr" or ext == "cbt" then
+        return directionFromComicInfo(document.file)
+    end
+
+    return nil
+end
+
+return M


### PR DESCRIPTION
## Summary

Automatically detects right-to-left page order on first open and switches
the reader accordingly — no manual configuration required.

**Supported formats:**
- EPUB: reads `page-progression-direction="rtl"` from the OPF `<spine>` element
- CBZ / CBR / CBT: reads `<ReadingDirection>RTL</ReadingDirection>` from `ComicInfo.xml`

When RTL is detected:
- A notification is shown ("RTL page order detected – switching automatically.")
- Page-turn direction is reversed (swipe left to advance)
- Progress bar fills right → left (page 1 on the right)

The detected result is stored in per-book settings (`direction_auto_detected`),
so re-scanning is skipped on subsequent opens. Manual overrides via
**Menu → Taps & gestures → Page turns** are always respected and take priority.

## Implementation

Detection uses `ffi/archiver` (libarchive) to read directly from the ZIP/EPUB
archive — no C++ changes required, cache-independent, works on first open.

**New files (no upstream conflict):**
- `frontend/util/page_direction.lua` — archive reading and direction parsing
- `frontend/apps/reader/modules/reader_auto_direction.lua` — EventListener module

**Modified upstream files (minimal):**
- `readerui.lua` — `require` + `registerModule` (8 lines)
- `readerview.lua` — progress bar sync with `inverse_reading_order` (12 lines)

## Test plan

- [ ] Open a manga EPUB with `page-progression-direction="rtl"` → notification + RTL
- [ ] Open a CBZ with `ComicInfo.xml` containing `<ReadingDirection>RTL</ReadingDirection>` → same
- [ ] Re-open the same book → no notification, direction persists from saved settings
- [ ] Manually toggle direction → survives re-open (user choice is respected)
- [ ] Open a normal LTR EPUB → no change, stays LTR