### PR TITLE
vertical-rl: fix ghost page from horizontal-mode image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,23 @@
 # KOReader Vertical Text (vertical-rl) Implementation
 
+## Soft Fork Policy
+
+This project is a soft fork of koreader/koreader + koreader/koreader-base +
+crengine, maintained as m-tky/koreader-tategumi, m-tky/koreader-base, and
+m-tky/crengine. Upstreaming is not the goal, but the fork must remain easy
+to rebase onto upstream updates. Therefore:
+
+- **Minimal, targeted changes**: Modify only the functions and files necessary
+  for the fix. Preserve upstream style, naming conventions, and comment culture.
+- **Do not touch upstream code unnecessarily**: Do not clean up commented-out
+  debug code or reorganize existing comments — this widens the diff for no gain.
+- **No debug code in commits**: Remove all diagnostic `fprintf(stderr, ...)`
+  and similar instrumentation before committing.
+- **Issues and PRs go to m-tky repos only**: Never open issues or PRs against
+  upstream repositories (koreader/koreader, etc.) by mistake.
+- **All written communication in English**: Code, comments, commit messages,
+  issues, PRs, and documentation must all be written in English.
+
 ## Project Goal
 
 Implement Japanese vertical-rl text rendering in KOReader/crengine.


### PR DESCRIPTION
Closes #8

## Changes

### crengine (`lvrend.cpp`)
Cap each `addContentLine` height at `eff_page_h` when `flow->isVertical()`.
A horizontal-mode image's `frmline.height` equals its screen-Y extent and
can exceed `eff_page_h` (the block-direction page stride in vertical-rl),
creating a ghost overflow page. Only the per-line height is capped; the
block element height (`fmt.setHeight`) is left uncapped to avoid shifting
siblings in the multi-line case.

### crengine (`lvtinydom.cpp`)
Walk the parent chain in `ldomNode::renderFinalBlock` to resolve
`effective_writing_mode` for elements whose own style has `css_wm_inherit`
(= 0). This ensures block-level images without an explicit `writing-mode`
CSS rule are formatted in the correct mode when an ancestor sets it.

### CLAUDE.md
Add soft fork policy section: keep changes minimal and targeted, do not
touch upstream code unnecessarily, write all communication in English.

## Test plan
- [ ] Open 独学大全 in the emulator: page 1 = cover image, page 2 = first text page (no ghost)
- [ ] Existing vertical text tests pass: `./kodev test front -f "Vertical text"`