### PR TITLE
vertical-rl: per-slot highlight sbox alignment (replaces per-font cache)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ The override is saved per-book and will not be overwritten on subsequent opens.
   groups and the following character. This is a property of the EPUB source, not a
   rendering bug.
 
+- **Multi-line highlights have slightly jagged top/bottom edges** (a few pixels of
+  variance between adjacent columns). This is a consequence of the underlying CREngine
+  being designed for horizontal text only. Vertical-rl is retrofitted via a Y=X
+  coordinate swap, which reuses the horizontal rendering pipeline but causes per-glyph
+  Y offsets (necessary to align individual highlights with their rendered glyphs in a
+  column-width slot) to leak into what would otherwise be line-level uniform values.
+  A proper fix would require writing-mode-aware logical-direction abstraction at the
+  layout-engine level — out of scope for this soft fork. Individual character highlights
+  remain pixel-accurate.
+
 ## Support
 
 If you find this vertical text fork useful, you can support its development:

--- a/spec/unit/vertical_highlight_slot_lookup_spec.lua
+++ b/spec/unit/vertical_highlight_slot_lookup_spec.lua
@@ -110,5 +110,50 @@ describe("Vertical text: per-slot offset record/lookup", function()
             string.format("docToWindowPoint did NOT hit any slot record (Δhits=%d).  "
                        .. "Formatter is keying records by a position the layout "
                        .. "doesn't store (likely clamped_x instead of word->x).", dh))
+
+        -- (4) Sbox height ≥ ~half its width for a single CJK char.
+        --     Vertical-rl sbox corners are paired (topLeft + bottomRight).  By
+        --     geometry the bottomRight's anchor lands on the column's opposite
+        --     edge and its slot_y at glyph_top+height — its own per-slot lookup
+        --     misses by design.  Before the offset-sharing fix the bottomRight
+        --     would fall back to the page-wide min while topLeft got a per-glyph
+        --     offset, producing a stunted sbox (h ≪ w) and the glyph poked out
+        --     below the highlight.  After the fix, bottomRight inherits the
+        --     topLeft's offset, so top and bottom shift uniformly.
+        --
+        --     We probe several positions; the bug presents as sbox h ≤ w/2
+        --     (pre-fix measured h=20, w=40 → ratio 0.5).  After offset-sharing
+        --     normal CJK glyphs land at h ≈ w (ratio ≈ 1.0), small punctuation
+        --     at h ≈ w/2+ε (still strictly > w/2).  Threshold `h*2 > w` is the
+        --     boundary that catches the regression without false-positiving on
+        --     legitimately short glyphs.  At least one probe must land on a
+        --     full-height glyph (ratio ≥ 0.9) to prove we did exercise the
+        --     non-stunted path.
+        local probed = 0
+        local saw_full = false
+        for _, fx in ipairs({0.85, 0.75, 0.65, 0.55, 0.45, 0.35}) do
+        for _, fy in ipairs({0.3, 0.5, 0.7}) do
+            local ok, wb = pcall(function()
+                return doc:getWordFromPosition({x = math.floor(sw * fx),
+                                                y = math.floor(sh * fy)})
+            end)
+            if ok and wb and wb.sbox and wb.sbox.w > 0 then
+                probed = probed + 1
+                assert.is_true(wb.sbox.h * 2 > wb.sbox.w,
+                    string.format("sbox stunted: w=%d h=%d (h must be > w/2; "
+                               .. "bottomRight is falling back to page-wide min "
+                               .. "instead of inheriting topLeft's per-glyph offset)",
+                               wb.sbox.w, wb.sbox.h))
+                if wb.sbox.h * 10 >= wb.sbox.w * 9 then  -- ratio >= 0.9
+                    saw_full = true
+                end
+            end
+        end
+        end
+        assert.is_true(probed > 0,
+            "no sbox returned by any probe — test cannot verify sbox height")
+        assert.is_true(saw_full,
+            "no probe hit a full-height CJK glyph — test did not exercise the "
+         .. "case the offset-sharing fix is intended to repair")
     end)
 end)

--- a/spec/unit/vertical_highlight_slot_lookup_spec.lua
+++ b/spec/unit/vertical_highlight_slot_lookup_spec.lua
@@ -1,0 +1,114 @@
+--[[--
+Vertical-rl per-slot offset record / lookup regression test.
+
+Detects the bug where docToWindowPoint's per-slot lookup misses all
+recorded entries and silently falls back to the page-wide min, leaving
+the highlight sbox shifted upward by (per_glyph_offset − min).
+
+Root cause guarded against:
+  At record time the formatter must key by `frmline->x + word->x`
+  (the layout-stored inline position used by getRectEx), NOT by
+  `clamped_x` (the per-draw running tracker, which can be bumped by
+  vert_min_next_x overlap correction).
+
+What this test asserts:
+  1. The page-render path actually populates the per-slot record table
+     (slot_count > 0).
+  2. Round-trip: each recorded entry self-looks-up to the recorded offset.
+  3. After a getWordFromPosition (which goes through docToWindowPoint),
+     the lookup hit count grows — i.e. at least one of the sbox corners
+     successfully matched a recorded slot.
+--]]
+
+local lfs = require("libs/libkoreader-lfs")
+
+describe("Vertical text: per-slot offset record/lookup", function()
+    local epub_path
+    for _, p in ipairs({
+        "spec/front/unit/data/fixtures/vertical_text/sanshiro.epub",
+    }) do
+        if lfs.attributes(p) then epub_path = p; break end
+    end
+
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui, doc
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI         = require("apps/reader/readerui")
+        Screen           = require("device").screen
+        UIManager        = require("ui/uimanager")
+    end)
+
+    before_each(function()
+        if not epub_path then return end
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(epub_path),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        doc = readerui.document
+    end)
+
+    after_each(function()
+        if readerui then readerui:onClose() end
+        UIManager:quit()
+    end)
+
+    it("records per-slot offsets and hits at sbox time #slot_lookup", function()
+        if not epub_path then pending("sanshiro.epub not found"); return end
+        if not (doc.isVerticalText and doc:isVerticalText()) then
+            pending("document is not vertical-rl"); return
+        end
+
+        -- Page 10: deep enough into body text that the formatter has plenty
+        -- of vertical CJK draws (cover/TOC pages produce only a few records).
+        local sw, sh = Screen:getWidth(), Screen:getHeight()
+        local Geom = require("ui/geometry")
+        local target_page = math.min(doc:getPageCount(), 10)
+        readerui.rolling:onGotoPage(target_page)
+        fastforward_ui_events()
+        -- Probe to force the formatter through the page (mirrors the existing
+        -- vertical_glyph_y_spec pattern that reliably triggers >100 draws).
+        for _, fx in ipairs({0.8, 0.5, 0.2}) do
+            pcall(function()
+                doc:getWordFromPosition({x = math.floor(sw * fx),
+                                         y = math.floor(sh * 0.5)})
+            end)
+        end
+
+        -- (1) Records exist.
+        local slot_count = doc._document:getVertSlotRecordCount()
+        assert.is_true(slot_count > 10,
+            string.format("only %d slot records — vertical formatter did not "
+                       .. "render the body block", slot_count))
+
+        -- (2) Round-trip: every recorded entry self-looks-up.
+        local SENTINEL = -987654
+        for i = 0, math.min(slot_count, 50) - 1 do
+            local a, s, o = doc._document:getVertSlotRecord(i)
+            local got = doc._document:lookupVertSlotOffset(a, s, SENTINEL)
+            assert.equals(o, got,
+                string.format("rec[%d] self-lookup mismatch: got %d expected %d", i, got, o))
+        end
+
+        -- (3) After a fresh getWordFromPosition, lookup must hit at least once.
+        --     If the formatter's record key drifts from what docToWindowPoint
+        --     computes (the original bug), every lookup misses → dh = 0 → fail.
+        local hits0 = doc._document:getVertSlotLookupCounts()
+        pcall(function()
+            doc:getWordFromPosition({x = math.floor(sw * 0.9),
+                                     y = math.floor(sh * 0.5)})
+        end)
+        local hits1 = doc._document:getVertSlotLookupCounts()
+        local dh = hits1 - hits0
+        assert.is_true(dh > 0,
+            string.format("docToWindowPoint did NOT hit any slot record (Δhits=%d).  "
+                       .. "Formatter is keying records by a position the layout "
+                       .. "doesn't store (likely clamped_x instead of word->x).", dh))
+    end)
+end)


### PR DESCRIPTION
## Summary

Replaces the per-font cached highlight Y offset with a per-glyph record table that aligns the highlight sbox with each character's actually-rendered glyph position in vertical-rl mode.

Resolves two visual symptoms reported in #10:

1. **Highlight shifted upward / downward** from the character — caused by the per-font cache being biased toward an outlier first-glyph offset
2. **Glyph poking out below the highlight** — caused by the sbox bottomRight corner falling back to the page-wide minimum offset while the topLeft used a per-glyph value, leaving the sbox stunted

The per-slot mechanism records each glyph's actual rendered position at draw time and looks it up at sbox conversion. The BR call now inherits TL's offset when its own lookup misses, so the sbox height matches the glyph height.

Closes #10.

## Commits

1. \`base: per-slot offset lookup for highlight sbox alignment\` — bumps base + adds \`spec/unit/vertical_highlight_slot_lookup_spec.lua\` (regression test: records populated, lookups round-trip, getWordFromPosition hits)
2. \`base: share TL offset to BR for vertical-rl sbox\` — bumps base + extends spec to assert sbox h * 2 > w (catches stunted-height regression)
3. \`README: document multi-column highlight jaggedness as known limitation\` — see below

## Known limitation documented in README

This PR makes individual character highlights pixel-accurate but leaves a few-pixel variance between adjacent columns in multi-line highlights. A proper fix would require writing-mode-aware logical-direction abstraction at the layout-engine level, which is out of scope for this soft fork. See the updated Known limitations section in README.md.

## Dependency

Depends on:
- m-tky/crengine#1
- m-tky/koreader-base#1

Merge in submodule order: crengine → base → koreader.

## Test plan

- [ ] Build: \`./kodev build -d emulator\` succeeds with the new base SHA
- [ ] Tests: \`./kodev test front -f "Vertical text"\` passes 95/95 (including the new \`vertical_highlight_slot_lookup\` spec)
- [ ] Visual: open sanshiro.epub, navigate to body text, highlight individual kanji (e.g. 「腰」「生」「蓋」) — highlight covers the glyph exactly, no upward/downward offset, no glyph poking out below
- [ ] Visual: highlight multiple consecutive characters across columns — top/bottom may have slight jaggedness (documented limitation), but no broken/missing highlights