### PR TITLE
Ignore rp fallback text in vertical ruby metrics

### DIFF
--- a/datastorage.lua
+++ b/datastorage.lua
@@ -76,6 +76,10 @@ function DataStorage:getDocSettingsHashDir()
     return self:getDataDir() .. "/hashdocsettings"
 end
 
+function DataStorage:getPatchesDir()
+    return self:getDataDir() .. "/patches"
+end
+
 --- Gets the full configuration/data path.
 -- @treturn string Directory path (e.g., /mnt/onboard/.adds/koreader)
 function DataStorage:getFullDataDir()

--- a/frontend/apps/reader/modules/readerannotation.lua
+++ b/frontend/apps/reader/modules/readerannotation.lua
@@ -66,14 +66,15 @@ function ReaderAnnotation:buildAnnotation(bm, highlights, init)
     return { -- annotation
         datetime         = bm.datetime, -- creation time, not changeable
         datetime_updated = nil,         -- last modification time
-        drawer           = hl.drawer,   -- highlight drawer
+        drawer           = hl.drawer,   -- highlight style
         color            = hl.color,    -- highlight color
         text             = bm.notes,    -- highlighted text, editable
         text_edited      = hl.edited,   -- true if highlighted text has been edited
         note             = note,        -- user's note, editable
+        note_format      = nil,         -- plain text, or "html" or "md"
         chapter          = chapter,     -- book chapter title
         pageno           = pageno,      -- book page number (continuous numbering, used by KOHighlights)
-        pageref          = pageref,     -- book page number (iff: reference pages or hidden flows)
+        pageref          = pageref,     -- book page number (iff: stable pages or hidden flows)
         page             = bm.page,     -- highlight location, xPointer or number (pdf)
         pos0             = bm.pos0,     -- highlight start position, xPointer (== page) or table (pdf)
         pos1             = bm.pos1,     -- highlight end position, xPointer or table (pdf)

--- a/frontend/apps/reader/modules/readerback.lua
+++ b/frontend/apps/reader/modules/readerback.lua
@@ -115,6 +115,12 @@ ReaderBack.onViewRecalculate = ReaderBack._onViewPossiblyUpdated
 ReaderBack.onPagePositionUpdated = ReaderBack._onViewPossiblyUpdated
 
 function ReaderBack:onBack()
+    -- If a link is selected, clear it first
+    if self.ui.link:isPageLinkSelected() then
+        self.ui.link:clearSelectedPageLink(true)
+        return true
+    end
+
     local back_in_reader = G_reader_settings:readSetting("back_in_reader", "previous_location")
     local back_to_exit = G_reader_settings:readSetting("back_to_exit", "prompt")
 

--- a/frontend/apps/reader/modules/readerbookmark.lua
+++ b/frontend/apps/reader/modules/readerbookmark.lua
@@ -1586,7 +1586,7 @@ function ReaderBookmark:onSearchBookmark()
             }
         },
     }
-    input_dialog:addWidget(separator)
+    input_dialog:addWidget(separator, nil, true) -- don't add to focus_manager.layout.
     check_button_highlight = CheckButton:new{
         text = " " .. self.display_prefix["highlight"] .. self.display_type["highlight"],
         checked = true,

--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -1285,15 +1285,32 @@ function ReaderHighlight:showChooseHighlightDialog(highlights)
 end
 
 function ReaderHighlight:showHighlightNoteOrDialog(index)
-    local bookmark_note = self.ui.annotation.annotations[index].note
+    local anno = self.ui.annotation.annotations[index]
+    local bookmark_note = anno.note
     if bookmark_note then
+        local note_format = anno.note_format
+        if not note_format then -- try simple heuristics
+            local s = bookmark_note:gsub("^%s*", ""):sub(1, 1)
+            if s == "<" then
+                note_format = "html"
+            elseif s == "#" or s == "*" or s == "[" then
+                note_format = "md"
+            end
+        end
+        local ratio_w, ratio_h
+        if note_format then
+            ratio_w, ratio_h = 0.9, 0.8
+        else
+            ratio_w, ratio_h = 0.8, 0.4
+        end
         local textviewer
         textviewer = TextViewer:new{
             title = _("Note"),
-            show_menu = false,
+            show_menu = note_format ~= nil,
             text = bookmark_note,
-            width = math.floor(math.min(self.screen_w, self.screen_h) * 0.8),
-            height = math.floor(math.max(self.screen_w, self.screen_h) * 0.4),
+            text_format = note_format,
+            width = math.floor(math.min(self.screen_w, self.screen_h) * ratio_w),
+            height = math.floor(math.max(self.screen_w, self.screen_h) * ratio_h),
             anchor = function()
                 return self:_getDialogAnchor(textviewer, index)
             end,

--- a/frontend/apps/reader/modules/readerlink.lua
+++ b/frontend/apps/reader/modules/readerlink.lua
@@ -1283,6 +1283,21 @@ function ReaderLink:onSelectPrevPageLink()
     return self:selectRelPageLink(-1)
 end
 
+function ReaderLink:isPageLinkSelected()
+    return self.cur_selected_page_link_num ~= nil
+end
+
+function ReaderLink:clearSelectedPageLink(dirty_ui)
+    if self.ui.paging then return end
+    self.cur_selected_page_link_num = nil
+    self.cur_selected_link = nil
+    self.document:highlightXPointer()
+    if dirty_ui then
+        UIManager:setDirty(self.dialog, "ui")
+    end
+    return true
+end
+
 function ReaderLink:selectRelPageLink(rel)
     if self.ui.paging then
         -- not implemented for now (see at doing like in showLinkBox()
@@ -1312,9 +1327,7 @@ function ReaderLink:selectRelPageLink(rel)
         end
     end
     if not self.cur_selected_page_link_num then
-        self.cur_selected_link = nil
-        self.document:highlightXPointer()
-        UIManager:setDirty(self.dialog, "ui")
+        self:clearSelectedPageLink(true)
         return
     end
     local selected_link = links[self.cur_selected_page_link_num]
@@ -1356,19 +1369,10 @@ end
 
 function ReaderLink:onPageUpdate()
     if self.cur_selected_link then
-        self.document:highlightXPointer()
-        self.cur_selected_page_link_num = nil
-        self.cur_selected_link = nil
+        self:clearSelectedPageLink()
     end
 end
-
-function ReaderLink:onPosUpdate()
-    if self.cur_selected_link then
-        self.document:highlightXPointer()
-        self.cur_selected_page_link_num = nil
-        self.cur_selected_link = nil
-    end
-end
+ReaderLink.onPosUpdate = ReaderLink.onPageUpdate
 
 function ReaderLink:onGoToLatestBookmark(ges)
     local latest_bookmark = self.ui.bookmark:getLatestBookmark()

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -8,6 +8,7 @@ local Archiver = require("ffi/archiver")
 local DataStorage = require("datastorage")
 local Event = require("ui/event")
 local Geom = require("ui/geometry")
+local NetInfo = require("ffi/netinfo")
 local UIManager -- Updated on UIManager init
 local logger = require("logger")
 local ffi = require("ffi")
@@ -20,6 +21,52 @@ local T = ffiUtil.template
 
 -- We'll need a bunch of stuff for getifaddrs & co in Device:retrieveNetworkInfo
 require("ffi/posix_h")
+
+ffi.cdef[[
+struct icmp_echo {
+  uint8_t type;
+  uint8_t code;
+  uint16_t checksum;
+  uint16_t id;
+  uint16_t sequence;
+};
+]]
+
+if ffi.abi("le") then
+    ffi.cdef[[
+struct ip_header
+{
+    unsigned int ihl:4;
+    unsigned int version:4;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t saddr;
+    uint32_t daddr;
+  };
+]]
+else
+    ffi.cdef[[
+struct ip_header
+{
+    unsigned int version:4;
+    unsigned int ihl:4;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t saddr;
+    uint32_t daddr;
+  };
+]]
+end
 
 local function yes() return true end
 local function no() return false end
@@ -683,10 +730,10 @@ function Device:ping4(ip)
 
     -- Setup the packet
     local packet = ffi.new("char[?]", DEFDATALEN + MAXIPLEN + MAXICMPLEN)
-    local pkt = ffi.cast("struct icmphdr *", packet)
+    local pkt = ffi.cast("struct icmp_echo *", packet)
     pkt.type = C.ICMP_ECHO
-    pkt.un.echo.id = myid
-    pkt.un.echo.sequence = C.htons(1)
+    pkt.id = myid
+    pkt.sequence = C.htons(1)
     pkt.checksum = inet_cksum(ffi.cast("const void *", pkt), ffi.sizeof(packet))
 
     -- Set the destination address
@@ -741,7 +788,7 @@ function Device:ping4(ip)
                 -- Do some minimal verification of the reply's validity.
                 -- This is mostly based on busybox's ping,
                 -- with some extra inspiration from iputils's ping, especially as far as SOCK_DGRAM is concerned.
-                local iphdr = ffi.cast("struct iphdr *", packet) -- ip + icmp
+                local iphdr = ffi.cast("struct ip_header *", packet) -- ip + icmp
                 local hlen
                 if socket_type == C.SOCK_RAW then
                     hlen = bit.lshift(iphdr.ihl, 2)
@@ -754,11 +801,11 @@ function Device:ping4(ip)
                     hlen = 0
                 end
                 -- Skip ip hdr to get at the ICMP part
-                local icp = ffi.cast("struct icmphdr *", packet + hlen)
+                local icp = ffi.cast("struct icmp_echo *", packet + hlen)
                 -- Check that we got a *reply* to *our* ping
                 -- NOTE: The reply's ident is defined by the kernel for SOCK_DGRAM, so we can't do anything with it!
                 if icp.type == C.ICMP_ECHOREPLY and
-                   (socket_type == C.SOCK_DGRAM or icp.un.echo.id == myid) then
+                   (socket_type == C.SOCK_DGRAM or icp.id == myid) then
                     break
                 end
             end
@@ -828,129 +875,42 @@ function Device:getDefaultRoute(interface)
 end
 
 function Device:retrieveNetworkInfo()
-    -- We're going to need a random socket for the network & wireless ioctls...
-    local socket = C.socket(C.PF_INET, C.SOCK_DGRAM, C.IPPROTO_IP);
-    if socket == -1 then
-        local errno = ffi.errno()
-        logger.err("Device:retrieveNetworkInfo: socket:", ffi.string(C.strerror(errno)))
-        return
-    end
-
-    local ifaddr = ffi.new("struct ifaddrs *[1]")
-    if C.getifaddrs(ifaddr) == -1 then
-        local errno = ffi.errno()
-        logger.err("Device:retrieveNetworkInfo: getifaddrs:", ffi.string(C.strerror(errno)))
-        return false
-    end
 
     -- Build a string rope to format the results
     local results = {}
-    local interfaces = {}
-    local prev_ifname, default_gw
+    local default_gw
 
-    -- Loop over all the network interfaces
-    local ifa = ifaddr[0]
-    while ifa ~= nil do
-        -- Skip over loopback or downed interfaces
-        if ifa.ifa_addr ~= nil and
-           bit.band(ifa.ifa_flags, C.IFF_UP) ~= 0 and
-           bit.band(ifa.ifa_flags, C.IFF_LOOPBACK) == 0 then
-            local family = ifa.ifa_addr.sa_family
-            if family == C.AF_INET or family == C.AF_INET6 then
-                local host = ffi.new("char[?]", C.NI_MAXHOST)
-                local s = C.getnameinfo(ifa.ifa_addr,
-                                        family == C.AF_INET and ffi.sizeof("struct sockaddr_in") or ffi.sizeof("struct sockaddr_in6"),
-                                        host, C.NI_MAXHOST,
-                                        nil, 0,
-                                        C.NI_NUMERICHOST)
-                if s ~= 0 then
-                    logger.err("Device:retrieveNetworkInfo: getnameinfo:", ffi.string(C.gai_strerror(s)))
-                else
-                    -- Only print the ifname once
-                    local ifname = ffi.string(ifa.ifa_name)
-                    if not interfaces[ifname] then
-                        if prev_ifname and ifname ~= prev_ifname then
-                            -- Add a linebreak between interfaces
-                            table.insert(results, "")
-                        end
-                        prev_ifname = ifname
-                        table.insert(results, T(_("Interface: %1"), ifname))
-                        interfaces[ifname] = true
-                        -- Get its MAC address
-                        local ifr = ffi.new("struct ifreq")
-                        ffi.copy(ifr.ifr_ifrn.ifrn_name, ifa.ifa_name, C.IFNAMSIZ)
-                        if C.ioctl(socket, C.SIOCGIFHWADDR, ifr) == -1 then
-                            local errno = ffi.errno()
-                            logger.err("Device:retrieveNetworkInfo: SIOCGIFHWADDR ioctl:", ffi.string(C.strerror(errno)))
-                        else
-                            local mac = string.format("%02X:%02X:%02X:%02X:%02X:%02X",
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[0], 0xFF),
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[1], 0xFF),
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[2], 0xFF),
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[3], 0xFF),
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[4], 0xFF),
-                                                      bit.band(ifr.ifr_ifru.ifru_hwaddr.sa_data[5], 0xFF))
-                            table.insert(results, T(_("MAC: %1"), mac))
-                        end
-
-                        -- Check if it's a wireless interface (c.f., wireless-tools)
-                        local iwr = ffi.new("struct iwreq")
-                        ffi.copy(iwr.ifr_ifrn.ifrn_name, ifa.ifa_name, C.IFNAMSIZ)
-                        if C.ioctl(socket, C.SIOCGIWNAME, iwr) ~= -1 then
-                            interfaces[ifname] = "wireless"
-                            -- Get its ESSID
-                            local essid = ffi.new("char[?]", C.IW_ESSID_MAX_SIZE + 1)
-                            iwr.u.essid.pointer = ffi.cast("caddr_t", essid)
-                            iwr.u.essid.length = C.IW_ESSID_MAX_SIZE + 1
-                            iwr.u.essid.flags = 0
-                            if C.ioctl(socket, C.SIOCGIWESSID, iwr) == -1 then
-                                local errno = ffi.errno()
-                                logger.err("Device:retrieveNetworkInfo: SIOCGIWESSID ioctl:", ffi.string(C.strerror(errno)))
-                            else
-                                local essid_on = iwr.u.data.flags
-                                if essid_on ~= 0 then
-                                    -- Knowing the token index may be fun, bit it isn't in fact, super interesting...
-                                    --[[
-                                    local token_index = bit.band(essid_on, C.IW_ENCODE_INDEX)
-                                    if token_index > 1 then
-                                        table.insert(results, T(_("SSID: \"%1\" [%2]"), ffi.string(essid), token_index))
-                                    else
-                                        table.insert(results, T(_("SSID: \"%1\""), ffi.string(essid)))
-                                    end
-                                    --]]
-                                    table.insert(results, T(_("SSID: \"%1\""), ffi.string(essid)))
-                                else
-                                    table.insert(results, _("SSID: off/any"))
-                                end
-                            end
-                        end
-                    end
-
-                    if family == C.AF_INET then
-                        table.insert(results, T(_("IP: %1"), ffi.string(host)))
-                        local gw = self:getDefaultRoute(ifname)
-                        if gw then
-                            table.insert(results, T(_("Default gateway: %1"), gw))
-                            -- If that's a wireless interface, use *that* one for the ping test
-                            if interfaces[ifname] == "wireless" then
-                                default_gw = gw
-                            end
-                        end
-                    else
-                        table.insert(results, T(_("IPv6: %1"), ffi.string(host)))
-                        --- @todo: Build an IPv6 variant of getDefaultRoute that parses /proc/net/ipv6_route
-                    end
+    local ni = NetInfo:new()
+    for __, iface in ipairs(ni:retrieve()) do
+        table.insert(results, T(_("Interface: %1"), iface.name))
+        table.insert(results, T(_("MAC: %1"), iface.mac))
+        if iface.wireless then
+            if iface.ssid then
+                table.insert(results, T(_("SSID: \"%1\""), iface.ssid))
+            else
+                table.insert(results, _("SSID: off/any"))
+            end
+        end
+        if iface.ipv4 then
+            table.insert(results, T(_("IPv4: %1"), iface.ipv4))
+            local gw = self:getDefaultRoute(iface.name)
+            if gw then
+                table.insert(results, T(_("Default gateway: %1"), gw))
+                -- If that's a wireless interface, use *that* one for the ping test
+                if iface.wireless == "wireless" then
+                    default_gw = gw
                 end
             end
         end
-        ifa = ifa.ifa_next
-    end
-    C.freeifaddrs(ifaddr[0])
-    C.close(socket)
-
-    if prev_ifname then
+        if iface.ipv6 then
+            table.insert(results, T(_("IPv6: %1"), iface.ipv6))
+            --- @todo: Build an IPv6 variant of getDefaultRoute that parses /proc/net/ipv6_route
+        end
+        -- Add a linebreak between interfaces
         table.insert(results, "")
     end
+    ni:free()
+
     -- Only ping a single gateway (if we found a wireless interface earlier, we've kept its gateway address around)
     if not default_gw then
         -- If not, we'll simply use the last one in the list...

--- a/frontend/device/generic/device.lua
+++ b/frontend/device/generic/device.lua
@@ -1053,7 +1053,7 @@ function Device:unpackArchive(archive, extract_to, with_stripped_root)
     end
     if not ok then
         return false, T(_("Extracting archive failed:\n\n%1"), BD.filepath(archive))..string.format("\n\n(%s)", arc.err)
-end
+    end
     arc:close()
     os.remove(archive)
     return true

--- a/frontend/document/document.lua
+++ b/frontend/document/document.lua
@@ -508,7 +508,7 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, saturation, hi
         dc:setSaturation(saturation)
     end
 
-    dc:setIsolateSMask(self.configurable.background_cleanup)
+    dc:setBackgroundCleanup(self.configurable.background_cleanup ~= 0)
 
     -- And finally, render the page in our BB
     local page = self._document:openPage(pageno)

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -221,7 +221,7 @@ function KoptInterface:getAutoBBox(doc, pageno)
     if not cached then
         local page = doc._document:openPage(pageno)
         local kc = self:createContext(doc, pageno, bbox)
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         local x0, y0, x1, y1 = kc:getAutoBBox()
         local w, h = native_size.w, native_size.h
         if (x1 - x0)/w > 0.1 or (y1 - y0)/h > 0.1 then
@@ -252,7 +252,7 @@ function KoptInterface:getSemiAutoBBox(doc, pageno)
         local page = doc._document:openPage(pageno)
         local kc = self:createContext(doc, pageno, bbox)
         local auto_bbox = {}
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         auto_bbox.x0, auto_bbox.y0, auto_bbox.x1, auto_bbox.y1 = kc:getAutoBBox()
         auto_bbox.x0 = auto_bbox.x0 + bbox.x0
         auto_bbox.y0 = auto_bbox.y0 + bbox.y0
@@ -309,7 +309,7 @@ function KoptInterface:reflowPage(doc, pageno, bbox, background)
     kc.zoom = (1.5 * kc.zoom * kc.quality * kc.dev_width) / bbox.x1
     -- Generate pixmap.
     local page = doc._document:openPage(pageno)
-    page:getPagePix(kc, doc.render_mode)
+    page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
     page:close()
     -- Reflow.
     if background then
@@ -456,7 +456,7 @@ function KoptInterface:renderOptimizedPage(doc, pageno, rect, zoom, rotation, hi
         local kc = self:createContext(doc, pageno, bbox)
         local page = doc._document:openPage(pageno)
         kc:setZoom(zoom)
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         page:close()
         logger.dbg("optimizing page", pageno)
         kc:optimizePage()
@@ -751,7 +751,7 @@ function KoptInterface:getPanelFromPage(doc, pageno, ges)
     local kc = self:createContext(doc, pageno, bbox)
     kc:setZoom(1.0)
     local page = doc._document:openPage(pageno)
-    page:getPagePix(kc, doc.render_mode)
+    page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
     local panel = kc:getPanelFromPage(ges)
     page:close()
     kc:free()
@@ -776,7 +776,7 @@ function KoptInterface:getNativeTextBoxesFromScratch(doc, pageno)
         local kc = self:createContext(doc, pageno, bbox)
         kc:setZoom(1.0)
         local page = doc._document:openPage(pageno)
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         local boxes, nr_word = kc:getNativeWordBoxes("src", 0, 0, page_size.w, page_size.h)
         if boxes then
             DocCache:insert(hash, CacheItem:new{ scratchnativepgboxes = boxes, size = 192 * nr_word }) -- estimation
@@ -810,7 +810,7 @@ function KoptInterface:getPageBlock(doc, pageno, x, y)
         -- leptonica needs a source image of at least 300dpi
         kc:setZoom(CanvasContext:getWidth() / page_size.w * 300 / CanvasContext:getDPI())
         local page = doc._document:openPage(pageno)
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         kc:findPageBlocks()
         DocCache:insert(hash, CacheItem:new{ kctx = kc, size = 3072 }) -- estimation
         page:close()
@@ -889,7 +889,7 @@ function KoptInterface:getNativeOCRWord(doc, pageno, rect)
         local kc = self:createContext(doc, pageno, bbox)
         kc:setZoom(30/rect.h)
         local page = doc._document:openPage(pageno)
-        page:getPagePix(kc, doc.render_mode)
+        page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
         --kc:exportSrcPNGFile({rect}, nil, "ocr-word.png")
         local word_w, word_h = kc:getPageDim()
         local _, word = pcall(
@@ -941,7 +941,7 @@ function KoptInterface:getClipPageContext(doc, pos0, pos1, pboxes, drawer)
     }
     local kc = self:createContext(doc, pos0.page, bbox)
     local page = doc._document:openPage(pos0.page)
-    page:getPagePix(kc, doc.render_mode)
+    page:getPagePix(kc, doc.render_mode, doc.configurable.background_cleanup)
     page:close()
     return kc, rect
 end

--- a/frontend/document/koptinterface.lua
+++ b/frontend/document/koptinterface.lua
@@ -19,6 +19,8 @@ local logger = require("logger")
 local util = require("util")
 local ffi = require("ffi")
 
+require "ffi/posix_h"
+
 local KoptInterface = {
     ocrengine = "ocrengine",
     -- If `$TESSDATA_PREFIX` is set, don't override it: let libk2pdfopt honor it
@@ -291,7 +293,6 @@ local function get_pthread()
     for _, libname in ipairs(candidates) do
         ok, cached_pthread = pcall(ffi.load, libname)
         if ok then
-            require("ffi/pthread_h")
             return cached_pthread
         end
     end

--- a/frontend/pluginloader.lua
+++ b/frontend/pluginloader.lua
@@ -209,7 +209,8 @@ function PluginLoader:_discover()
                 local metafile = plugin_root.."/_meta.lua"
                 local plugin_name = entry:sub(1, -10)
                 local disabled = false
-                if plugins_disabled and plugins_disabled[plugin_name] then
+                if (plugins_disabled and plugins_disabled[plugin_name]) or
+                        (G_reader_settings:isTrue("plugins_disable_external") and not BUILTIN_PLUGINS[plugin_name]) then
                     mainfile = metafile
                     disabled = true
                 end
@@ -312,6 +313,9 @@ function PluginLoader:genPluginManagerSubItem()
     for _, plugin in ipairs(self.all_plugins) do
         local item = {
             text = plugin.fullname,
+            enabled_func = function()
+                return BUILTIN_PLUGINS[plugin.name] or G_reader_settings:nilOrFalse("plugins_disable_external")
+            end,
             checked_func = function()
                 return plugin.enable
             end,

--- a/frontend/ui/data/onetime_migration.lua
+++ b/frontend/ui/data/onetime_migration.lua
@@ -12,7 +12,7 @@ local util = require("util")
 local _ = require("gettext")
 
 -- Date at which the last migration snippet was added
-local CURRENT_MIGRATION_DATE = 20260517
+local CURRENT_MIGRATION_DATE = 20260623
 
 -- Retrieve the date of the previous migration, if any
 local last_migration_date = G_reader_settings:readSetting("last_migration_date", 0)
@@ -1009,6 +1009,19 @@ if last_migration_date < 20260517 then
             recursive_directory = recursive_directory,
         })
         settings:flush()
+    end
+end
+
+-- 20260623, Move Kosync plugin settings into a separate file
+-- https://github.com/koreader/koreader/pull/15591
+if last_migration_date < 20260623 then
+    logger.info("Performing one-time migration for 20260623")
+    local kosync_setting = G_reader_settings:readSetting("kosync")
+    if kosync_setting then
+        local settings = LuaSettings:open(DataStorage:getSettingsDir() .. "/kosync.lua")
+        settings:saveSetting("settings" , kosync_setting)
+        settings:flush()
+        G_reader_settings:delSetting("kosync")
     end
 end
 

--- a/frontend/ui/elements/common_info_menu_table.lua
+++ b/frontend/ui/elements/common_info_menu_table.lua
@@ -1,5 +1,6 @@
 local BD = require("ui/bidi")
 local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
 local Device = require("device")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
@@ -8,6 +9,7 @@ local UIManager = require("ui/uimanager")
 local Version = require("version")
 local dbg = require("dbg")
 local lfs = require("libs/libkoreader-lfs")
+local userpatch = require("userpatch")
 local _ = require("gettext")
 local T = require("ffi/util").template
 
@@ -52,7 +54,6 @@ common_info.report_bug = {
     end,
     keep_menu_open = true,
     callback = function(touchmenu_instance)
-        local DataStorage = require("datastorage")
         local log_path = string.format("%s/%s", DataStorage:getDataDir(), "crash.log")
         local common_msg = T(_("Please report bugs to \nhttps://github.com/koreader/koreader/issues\n\nVersion:\n%1\n\nDetected device:\n%2"),
             Version:getCurrentRevision(), Device:info())
@@ -102,6 +103,17 @@ common_info.report_bug = {
             }},
         })
     end
+}
+common_info.plugins_disable_external = {
+    text = _("Disable external plugins and user-patches"),
+    checked_func = function()
+        return G_reader_settings:isTrue("plugins_disable_external")
+    end,
+    callback = function()
+        G_reader_settings:flipNilOrFalse("plugins_disable_external")
+        userpatch.togglePatchesDisabled()
+        UIManager:askForRestart()
+    end,
 }
 common_info.version = {
     text = T(_("Version: %1"), Version:getShortVersion()),

--- a/frontend/ui/elements/filemanager_menu_order.lua
+++ b/frontend/ui/elements/filemanager_menu_order.lua
@@ -190,6 +190,7 @@ local order = {
         "search_menu",
         "----------------------------",
         "report_bug",
+        "plugins_disable_external",
         "----------------------------",
         "system_statistics", -- if enabled (Plugin)
         "version",

--- a/frontend/ui/elements/patch_management.lua
+++ b/frontend/ui/elements/patch_management.lua
@@ -1,7 +1,7 @@
 local DataStorage = require("datastorage")
 local lfs = require("libs/libkoreader-lfs")
 
-local patch_dir = DataStorage:getDataDir() .. "/patches"
+local patch_dir = DataStorage:getPatchesDir()
 if lfs.attributes(patch_dir, "mode") ~= "directory" then return end
 
 local InfoMessage = require("ui/widget/infomessage")
@@ -50,6 +50,7 @@ local function done_callback()
 end
 
 local function genSubMenu(priority)
+    local patches_enabled = not userPatch.arePatchesDisabled()
     local sub_menu = {}
     for i, patch in ipairs(patches[priority]) do
         local ext = ".lua"
@@ -57,8 +58,11 @@ local function genSubMenu(priority)
         local patch_name = patch:sub(1, patch:find(ext, 1, true) + ext:len() - 1)
         sub_menu[i] = {
             text = patch_name:sub(1, -5) .. (userPatch.execution_status[patch_name] == false and " ⚠" or ""),
+            enabled_func = function()
+                return patches_enabled
+            end,
             checked_func = function()
-                return patch:find("%.lua$") ~= nil
+                return patches_enabled and patch:find("%.lua$") ~= nil
             end,
             callback = function()
                 local extension_pos = patch:find(ext, 1, true)

--- a/frontend/ui/elements/reader_menu_order.lua
+++ b/frontend/ui/elements/reader_menu_order.lua
@@ -250,6 +250,7 @@ local order = {
         "search_menu",
         "----------------------------",
         "report_bug",
+        "plugins_disable_external",
         "----------------------------",
         "system_statistics",  -- if enabled (Plugin)
         "version",

--- a/frontend/ui/network/manager.lua
+++ b/frontend/ui/network/manager.lua
@@ -30,6 +30,10 @@ local NetworkMgr = {
     pending_connectivity_check = false,
     pending_connection = false,
     _before_action_tripped = nil,
+
+    -- SSID for which the current DHCP lease was obtained.
+    -- Used by hasLeaseForCurrentNetwork() to detect stale leases after a network switch (#14790).
+    lease_ssid = nil,
 }
 
 function NetworkMgr:readNWSettings()
@@ -43,6 +47,8 @@ function NetworkMgr:_abortWifiConnection()
 
     self.wifi_was_on = false
     G_reader_settings:makeFalse("wifi_was_on")
+    -- The connection never completed, so any DHCP lease we may have had is no longer valid.
+    self.lease_ssid = nil
     -- Murder Wi-Fi and the async script (if any) first...
     if Device:hasWifiRestore() and not Device:isKindle() then
         os.execute("pkill -TERM restore-wifi-async.sh 2>/dev/null")
@@ -92,6 +98,14 @@ function NetworkMgr:connectivityCheck(iter, callback, widget)
         self.wifi_was_on = true
         G_reader_settings:makeTrue("wifi_was_on")
         logger.info("Wi-Fi successfully restored (after", iter * 0.25, "seconds)!")
+        -- Update lease_ssid from wpa_supplicant's current association.
+        -- restoreWifiAsync() re-DHCPs in shell but never touches Lua state, so we sync
+        -- here to avoid falsely flagging a valid post-restore lease as stale (#14790).
+        local nw = self:getCurrentNetwork()
+        if nw and nw.ssid then
+            self.lease_ssid = nw.ssid
+            logger.dbg("NetworkMgr: lease_ssid set to", nw.ssid, "after async restore")
+        end
         UIManager:broadcastEvent(Event:new("NetworkConnected"))
 
         -- Handle the UI & callback if it's from a beforeWifiAction...
@@ -278,6 +292,26 @@ function NetworkMgr:ifHasAnAddress()
     return ok
 end
 
+-- Returns true if the current DHCP lease was obtained for the network we are presently
+-- associated with.  Detects the stale-lease case that occurs after a network switch:
+-- wpa_supplicant has already roamed to the new SSID at L2, but the old IP/gateway are
+-- still assigned, so every outbound connection is routed to the wrong subnet (#14790).
+--
+-- When the backend cannot report the current SSID (non-wpa_supplicant platforms, or when
+-- wpa_supplicant is not yet fully associated) we return true so as not to churn a
+-- connection we cannot reliably assess.
+function NetworkMgr:hasLeaseForCurrentNetwork()
+    if not self:isConnected() then
+        return false
+    end
+    local nw = self:getCurrentNetwork()   -- wpa_supplicant's currently associated network
+    if not nw or not nw.ssid then
+        -- Backend can't tell us the SSID; don't disrupt the connection on uncertainty.
+        return true
+    end
+    return self.lease_ssid ~= nil and self.lease_ssid == nw.ssid
+end
+
 -- The socket API equivalent of "ip route get 203.0.113.1 || ip route get 2001:db8::1".
 --
 -- These addresses are from special ranges reserved for documentation
@@ -368,6 +402,8 @@ function NetworkMgr:enableWifi(wifi_cb, interactive)
 end
 
 function NetworkMgr:disableWifi(cb, interactive)
+    -- DHCP lease is released when Wi-Fi goes down, so the tracked SSID is no longer valid.
+    self.lease_ssid = nil
     local complete_callback = function()
         UIManager:broadcastEvent(Event:new("NetworkDisconnected"))
         if cb then
@@ -479,15 +515,25 @@ function NetworkMgr:promptWifi(complete_callback, long_press, interactive)
 end
 
 function NetworkMgr:turnOnWifiAndWaitForConnection(callback)
-    -- Just run the callback if WiFi is already up...
+    -- Just run the callback if WiFi is already up *and* the lease is for the current network.
     if self:isWifiOn() and self:isConnected() then
-        --- @note: beforeWifiAction only guarantees isConnected, not isOnline.
-        --         In the rare cases we're isConnected but !isOnline, if we're called via a *runWhenOnline wrapper,
-        --         we don't get a callback at all to avoid infinite recursion, so we need to check it.
-        if callback then
-            callback()
+        if self:hasLeaseForCurrentNetwork() then
+            --- @note: beforeWifiAction only guarantees isConnected, not isOnline.
+            --         In the rare cases we're isConnected but !isOnline, if we're called via a *runWhenOnline wrapper,
+            --         we don't get a callback at all to avoid infinite recursion, so we need to check it.
+            if callback then
+                callback()
+            end
+            return
         end
-        return
+        -- The DHCP lease belongs to a different network than the one wpa_supplicant is
+        -- currently associated with (stale lease after a network switch, #14790).
+        -- Release the old address and fall through to the normal reconnect path, which
+        -- will re-associate and re-run obtainIP() for the current network.
+        logger.info("NetworkMgr: stale DHCP lease detected (lease_ssid=", self.lease_ssid, "), forcing re-DHCP for current network")
+        self:releaseIP()
+        self.lease_ssid = nil
+        -- fall through — no return
     end
 
     local info = InfoMessage:new{ text = _("Connecting to Wi-Fi…") }
@@ -522,10 +568,17 @@ end
 -- This is only used on Android, the intent being we assume the system will eventually turn on WiFi on its own in the background...
 function NetworkMgr:doNothingAndWaitForConnection(callback)
     if self:isWifiOn() and self:isConnected() then
-        if callback then
-            callback()
+        if self:hasLeaseForCurrentNetwork() then
+            if callback then
+                callback()
+            end
+            return
         end
-        return
+        -- Stale lease after a network switch; drop it and fall through (#14790).
+        logger.info("NetworkMgr: stale DHCP lease detected (lease_ssid=", self.lease_ssid, "), forcing re-DHCP for current network")
+        self:releaseIP()
+        self.lease_ssid = nil
+        -- fall through — no return
     end
 
     self:scheduleConnectivityCheck(callback)
@@ -1162,6 +1215,10 @@ function NetworkMgr:reconnectOrShowNetworkMenu(complete_callback, interactive)
 
     if success then
         self:obtainIP()
+        -- Record the SSID we just obtained a lease for, so hasLeaseForCurrentNetwork()
+        -- can detect a future network switch without triggering unnecessary re-DHCPs (#14790).
+        self.lease_ssid = ssid
+        logger.dbg("NetworkMgr: lease_ssid set to", ssid)
         if complete_callback then
             complete_callback()
         end

--- a/frontend/ui/widget/inputdialog.lua
+++ b/frontend/ui/widget/inputdialog.lua
@@ -522,9 +522,11 @@ function InputDialog:reinit()
     UIManager:setDirty("all", "flashui")
 end
 
-function InputDialog:addWidget(widget, re_init)
+function InputDialog:addWidget(widget, re_init, skip_focus_layout)
     local is_text_height_adjustable = self.fullscreen or self.use_available_height
-    table.insert(self.layout, #self.layout, {widget})
+    if not skip_focus_layout then
+        table.insert(self.layout, #self.layout, {widget})
+    end
     if not re_init then -- backup widget for re-init
         widget = CenterContainer:new{
             dimen = Geom:new{

--- a/frontend/userpatch.lua
+++ b/frontend/userpatch.lua
@@ -35,8 +35,26 @@ local DataStorage = require("datastorage")
 
 -- the directory KOReader is installed in (and runs from)
 local package_dir = lfs.currentdir()
--- the directory where KOReader stores user data
-local data_dir = DataStorage:getDataDir()
+local patch_dir = DataStorage:getPatchesDir()
+local patches_disabled_path = patch_dir .. "/.patches_disabled"
+local patches_disabled = lfs.attributes(patches_disabled_path, "mode") == "file"
+
+function userpatch.arePatchesDisabled()
+    return patches_disabled
+end
+
+function userpatch.togglePatchesDisabled()
+    if patches_disabled then
+        os.remove(patches_disabled_path)
+        patches_disabled = false
+    else
+        local file = io.open(patches_disabled_path, "w")
+        if file then
+            file:close()
+            patches_disabled = true
+        end
+    end
+end
 
 --- Run lua patches
 -- Execution order order is alphanum-sort for humans version 4: `1-patch.lua` is executed before `10-patch.lua`
@@ -90,7 +108,7 @@ end
 --- This function applies lua patches from `/koreader/patches`
 ---- @string priority ... one of the defined priorities in the userpatch hashtable
 function userpatch.applyPatches(priority)
-    local patch_dir = data_dir .. "/patches"
+    if patches_disabled then return end
     local update_once_marker = package_dir .. "/update_once.marker"
     local update_once_pending = lfs.attributes(update_once_marker, "mode") == "file"
 

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -85,6 +85,7 @@ if [ "${1}" = "--kual" ]; then
     REEXEC_FLAGS="${REEXEC_FLAGS} --kual"
 else
     FROM_KUAL="no"
+    export EIPS_NO_SLEEP="yes"
 fi
 
 # By default, don't stop the framework.
@@ -98,8 +99,7 @@ elif [ "${1}" = "--asap" ]; then
     shift 1
     NO_SLEEP="yes"
     REEXEC_FLAGS="${REEXEC_FLAGS} --asap"
-    # Don't sleep during eips calls either...
-    export EIPS_NO_SLEEP="true"
+    export EIPS_NO_SLEEP="yes"
 else
     NO_SLEEP="no"
 fi
@@ -149,7 +149,7 @@ ko_update_check() {
         #       which we cannot use because it's been mounted noexec for a few years now...
         cp -pf "${KOREADER_DIR}/tar" /var/tmp/gnutar
         # shellcheck disable=SC2016
-        /var/tmp/gnutar --no-same-permissions --no-same-owner --checkpoint="${CPOINTS}" --checkpoint-action=exec='printf "%s" $((TAR_CHECKPOINT / CPOINTS)) > ${FBINK_NAMED_PIPE}' -C "/mnt/us" -xf "${NEWUPDATE}"
+        /var/tmp/gnutar --no-same-permissions --no-same-owner --checkpoint="${CPOINTS}" --checkpoint-action=exec='printf "%s" $((TAR_CHECKPOINT / CPOINTS)) > ${FBINK_NAMED_PIPE}' -C "${UNPACK_DIR}" -xf "${NEWUPDATE}"
         fail=$?
         kill -TERM "${FBINK_PID}"
         # And remove our temporary tar binary...

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -270,11 +270,9 @@ if [ "${STOP_FRAMEWORK}" = "no" ] && [ "${INIT_TYPE}" = "upstart" ]; then
                     logmsg "Title bar geometry: '${TITLEBAR_GEOMETRY}' -> '$("${KOREADER_DIR}/wmctrl" -l -G | grep ":titleBar_ID:" | awk '{print $2,$3,$4,$5,$6}' OFS=',')'"
                     USED_WMCTRL="yes"
                 fi
-                if [ "${FROM_KUAL}" = "yes" ]; then
-                    logmsg "Stopping awesome . . ."
-                    killall -STOP awesome
-                    AWESOME_STOPPED="yes"
-                fi
+                logmsg "Stopping awesome . . ."
+                killall -STOP awesome
+                AWESOME_STOPPED="yes"
             fi
         else
             logmsg "Hiding the status bar . . ."

--- a/platform/kindle/koreader.sh
+++ b/platform/kindle/koreader.sh
@@ -3,7 +3,7 @@
 export LC_ALL="en_US.UTF-8"
 
 # Compute our working directory in an extremely defensive manner
-SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"
+SCRIPT_DIR="$(CDPATH='' cd "$(dirname "$0")" && pwd -P)"
 # NOTE: We need to remember the *actual* KOREADER_DIR, not the relocalized version in /tmp...
 export KOREADER_DIR="${KOREADER_DIR:-${SCRIPT_DIR}}"
 UNPACK_DIR="${KOREADER_DIR%/*}"

--- a/plugins/kosync.koplugin/main.lua
+++ b/plugins/kosync.koplugin/main.lua
@@ -1,9 +1,11 @@
 local ConfirmBox = require("ui/widget/confirmbox")
+local DataStorage = require("datastorage")
 local Device = require("device")
 local Dispatcher = require("dispatcher")
 local Event = require("ui/event")
 local InfoMessage = require("ui/widget/infomessage")
 local InputDialog = require("ui/widget/inputdialog")
+local LuaSettings = require("luasettings")
 local Math = require("optmath")
 local MultiInputDialog = require("ui/widget/multiinputdialog")
 local NetworkMgr = require("ui/network/manager")
@@ -21,7 +23,8 @@ local KOSync = WidgetContainer:extend{
     name = "kosync",
     is_doc_only = true,
     title = _("Register/login to KOReader server"),
-    settings_key = "kosync",
+    settings_file = DataStorage:getSettingsDir() .. "/kosync.lua",
+    updated = nil,
 
     push_timestamp = nil,
     pull_timestamp = nil,
@@ -63,6 +66,20 @@ KOSync.default_settings = {
     send_metadata = false,
 }
 
+function KOSync:loadSettings()
+    if not KOSync.settings_obj then
+        KOSync.settings_obj = LuaSettings:open(self.settings_file)
+    end
+    self.settings = KOSync.settings_obj:readSetting("settings", KOSync.default_settings)
+end
+
+function KOSync:onFlushSettings()
+    if self.updated then
+        KOSync.settings_obj:flush()
+        self.updated = nil
+    end
+end
+
 function KOSync:init()
     self.push_timestamp = 0
     self.pull_timestamp = 0
@@ -78,8 +95,7 @@ function KOSync:init()
         -- We do *NOT* want to make sure networking is up here, as the nagging would be extremely annoying; we're leaving that to the network activity check...
         self:updateProgress(false, false)
     end
-
-    self.settings = G_reader_settings:readSetting(self.settings_key, self.default_settings)
+    self:loadSettings()
     self.device_id = G_reader_settings:readSetting("device_id")
 
     -- Disable auto-sync if beforeWifiAction was reset to "prompt" behind our back...
@@ -200,6 +216,7 @@ function KOSync:addToMainMenu(menu_items)
                         input = self.settings.custom_server or "https://",
                         callback = function(input)
                             self:setCustomServer(input)
+                            self.updated = true
                         end,
                     }
                 end,
@@ -230,6 +247,7 @@ function KOSync:addToMainMenu(menu_items)
                                         local hostname = dialog:getInputText()
                                         logger.dbg("KOSync: Setting custom hostname to:", hostname)
                                         self.settings.kosync_hostname = hostname ~= "" and hostname or nil
+                                        self.updated = true
                                         UIManager:close(dialog)
                                     end,
                                 },
@@ -250,6 +268,7 @@ function KOSync:addToMainMenu(menu_items)
                     if self.settings.userkey then
                         return function(menu)
                             self:logout(menu)
+                            self.updated = true
                         end
                     else
                         return function(menu)
@@ -265,6 +284,7 @@ function KOSync:addToMainMenu(menu_items)
                 help_text = _([[This may lead to nagging about toggling WiFi on document close and suspend/resume, depending on the device's connectivity.]]),
                 callback = function()
                     self:onKOSyncToggleAutoSync(nil, true)
+                    self.updated = true
                 end,
             },
             {
@@ -291,6 +311,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         callback = function(spin)
                             self:setPagesBeforeUpdate(spin.value)
                             if touchmenu_instance then touchmenu_instance:updateItems() end
+                            self.updated = true
                         end
                     }
                     UIManager:show(items)
@@ -313,6 +334,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.SILENT)
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -322,6 +344,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.PROMPT)
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -331,6 +354,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncForward(SYNC_STRATEGY.DISABLE)
+                                    self.updated = true
                                 end,
                             },
                         }
@@ -347,6 +371,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.SILENT)
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -356,6 +381,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.PROMPT)
+                                    self.updated = true
                                 end,
                             },
                             {
@@ -365,6 +391,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                                 end,
                                 callback = function()
                                     self:setSyncBackward(SYNC_STRATEGY.DISABLE)
+                                    self.updated = true
                                 end,
                             },
                         }
@@ -401,6 +428,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.BINARY)
+                            self.updated = true
                         end,
                     },
                     {
@@ -410,6 +438,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                         end,
                         callback = function()
                             self:setChecksumMethod(CHECKSUM_METHOD.FILENAME)
+                            self.updated = true
                         end,
                     },
                 }
@@ -420,6 +449,7 @@ If set to 0, updating progress based on page turns will be disabled.]]),
                 help_text = _([[When enabled, document metadata (filename, title, and authors) will be sent along with progress sync requests. This data is ignored by the official sync server but may be used by custom sync servers.]]),
                 callback = function()
                     self.settings.send_metadata = not self.settings.send_metadata
+                    self.updated = true
                 end,
             },
         }
@@ -554,6 +584,7 @@ function KOSync:doRegister(username, password, menu)
         if menu then
             menu:updateItems()
         end
+        self.updated = true
         UIManager:show(InfoMessage:new{
             text = _("Registered to KOReader server."),
         })
@@ -590,6 +621,7 @@ function KOSync:doLogin(username, password, menu)
     elseif status then
         self.settings.username = username
         self.settings.userkey = userkey
+        self.updated = true
         if menu then
             menu:updateItems()
         end
@@ -983,6 +1015,7 @@ function KOSync:onKOSyncToggleAutoSync(toggle, from_menu)
         return true
     end
     self.settings.auto_sync = not self.settings.auto_sync
+    self.updated = true
     self:registerEvents()
 
     if self.settings.auto_sync then

--- a/plugins/terminal.koplugin/main.lua
+++ b/plugins/terminal.koplugin/main.lua
@@ -12,20 +12,6 @@ local ffi = require("ffi")
 local C = ffi.C
 require("ffi/posix_h")
 
--- for terminal emulator
-ffi.cdef[[
-static const int SIGTERM = 15;
-
-int grantpt(int fd) __attribute__((nothrow, leaf));
-int unlockpt(int fd) __attribute__((nothrow, leaf));
-char *ptsname(int fd) __attribute__((nothrow, leaf));
-pid_t setsid(void) __attribute__((nothrow, leaf));
-
-static const int TCIFLUSH = 0;
-int tcdrain(int fd) __attribute__((nothrow, leaf));
-int tcflush(int fd, int queue_selector) __attribute__((nothrow, leaf));
-]]
-
 local function check_prerequisites()
     -- We of course need to be able to manipulate pseudoterminals,
     -- but Kobo's init scripts fail to set this up...

--- a/spec/unit/network_manager_spec.lua
+++ b/spec/unit/network_manager_spec.lua
@@ -79,3 +79,72 @@ describe("network_manager module", function()
         package.loaded["ui/network/manager"] = nil
     end)
 end)
+
+describe("NetworkMgr:hasLeaseForCurrentNetwork", function()
+    local NetworkMgr
+
+    setup(function()
+        require("commonrequire")
+        local Device = require("device")
+        function Device:initNetworkManager(mgr)
+            -- Minimal stubs so manager.lua initialises without errors.
+            function mgr:turnOnWifi() end
+            function mgr:turnOffWifi() end
+            function mgr:obtainIP() end
+            function mgr:releaseIP() end
+            function mgr:restoreWifiAsync() end
+        end
+        function Device:hasWifiRestore() return false end
+    end)
+
+    before_each(function()
+        package.loaded["ui/network/manager"] = nil
+        G_reader_settings:saveSetting("wifi_was_on", false)
+        NetworkMgr = require("ui/network/manager")
+    end)
+
+    after_each(function()
+        package.loaded["ui/network/manager"] = nil
+    end)
+
+    it("returns false when not connected", function()
+        -- Override isConnected so we don't need a real interface.
+        function NetworkMgr:isConnected() return false end
+        assert.is_false(NetworkMgr:hasLeaseForCurrentNetwork())
+    end)
+
+    it("returns true when backend cannot report an SSID (non-wpa_supplicant platforms)", function()
+        function NetworkMgr:isConnected() return true end
+        -- getCurrentNetwork() is a no-op stub that returns nil on non-Kobo builds.
+        function NetworkMgr:getCurrentNetwork() return nil end
+        assert.is_true(NetworkMgr:hasLeaseForCurrentNetwork())
+    end)
+
+    it("returns true when connected and lease matches the current SSID (no churn)", function()
+        function NetworkMgr:isConnected() return true end
+        function NetworkMgr:getCurrentNetwork() return {ssid = "HomeNet"} end
+        NetworkMgr.lease_ssid = "HomeNet"
+        assert.is_true(NetworkMgr:hasLeaseForCurrentNetwork())
+    end)
+
+    it("returns false when lease_ssid differs from current SSID (stale lease)", function()
+        function NetworkMgr:isConnected() return true end
+        function NetworkMgr:getCurrentNetwork() return {ssid = "OfficeNet"} end
+        NetworkMgr.lease_ssid = "HomeNet"   -- still holds the lease from the old network
+        assert.is_false(NetworkMgr:hasLeaseForCurrentNetwork())
+    end)
+
+    it("returns false when lease_ssid is nil even though a SSID is reported", function()
+        function NetworkMgr:isConnected() return true end
+        function NetworkMgr:getCurrentNetwork() return {ssid = "SomeNet"} end
+        NetworkMgr.lease_ssid = nil
+        assert.is_false(NetworkMgr:hasLeaseForCurrentNetwork())
+    end)
+
+    teardown(function()
+        local Device = require("device")
+        function Device:initNetworkManager() end
+        function Device:hasWifiRestore() return false end
+        package.loaded["ui/network/manager"] = nil
+    end)
+end)

--- a/spec/unit/ruby_position_spec.lua
+++ b/spec/unit/ruby_position_spec.lua
@@ -151,13 +151,27 @@ describe("Ruby position", function()
                 table.sort(strides)
                 return strides[math.ceil(#strides / 2)]
             end
+            local function first_body_y(words)
+                if #words < 5 then return nil end
+                local max_h = 0
+                for _, w in ipairs(words) do
+                    if w.sbox.h > max_h then max_h = w.sbox.h end
+                end
+                local h_threshold = max_h * 0.75
+                for _, w in ipairs(words) do
+                    if w.sbox.h >= h_threshold and w.sbox.h <= max_h then
+                        return w.sbox.y
+                    end
+                end
+                return nil
+            end
 
             local step = math.max(4, math.floor(h / 80))
             local strides = {}
             for _, x in ipairs(cols) do
                 local words = scan_column_trusted(doc, x, 5, h - 5, step)
                 local s = median_stride(words)
-                if s then table.insert(strides, {x=x, stride=s, n=#words}) end
+                if s then table.insert(strides, {x=x, stride=s, n=#words, first_y=first_body_y(words)}) end
             end
 
             if #strides < 2 then
@@ -165,32 +179,75 @@ describe("Ruby position", function()
                 return
             end
 
-            -- Find the MIN stride (most compressed) and MAX stride (uncompressed).
-            local min_s, max_s = strides[1].stride, strides[1].stride
-            local min_x, max_x = strides[1].x, strides[1].x
+            -- Find the MAX stride among justified/non-compressed columns.
+            local max_s = strides[1].stride
+            local max_x = strides[1].x
             for _, s in ipairs(strides) do
-                if s.stride < min_s then min_s = s.stride; min_x = s.x end
                 if s.stride > max_s then max_s = s.stride; max_x = s.x end
             end
 
-            -- Without the bug, all columns should have the SAME stride within tight
-            -- rounding tolerance (≤ 0.5px).  With the bug, the indented column is
-            -- compressed by ~1px per pair, so its median stride differs from the
-            -- non-indented columns by ~1px.
-            local stride_diff = max_s - min_s
-            assert.truthy(stride_diff <= 0.5,
-                string.format(
-                    "Column stride mismatch (compression detected): "..
-                    "min_stride=%.2fpx at col_x=%d, max_stride=%.2fpx at col_x=%d, diff=%.2fpx\n"..
-                    "(All strides: %s)",
-                    min_s, min_x, max_s, max_x, stride_diff,
-                    (function()
-                        local parts = {}
-                        for _, s in ipairs(strides) do
-                            table.insert(parts, string.format("x=%d stride=%.1f n=%d", s.x, s.stride, s.n))
+            -- With JFM enabled, final columns under text-align-last:auto are not
+            -- justified and may keep their natural 1.5em kana-comma stride. This
+            -- regression only cares that text-indent columns are not compressed.
+            local checked = 0
+            for _, s in ipairs(strides) do
+                if s.first_y and s.first_y > 30 then
+                    checked = checked + 1
+                    local stride_diff = max_s - s.stride
+                    assert.truthy(stride_diff <= 0.5,
+                        string.format(
+                            "Indented column stride mismatch (compression detected): "..
+                            "stride=%.2fpx at col_x=%d first_y=%d, max_stride=%.2fpx at col_x=%d, diff=%.2fpx\n"..
+                            "(All strides: %s)",
+                            s.stride, s.x, s.first_y, max_s, max_x, stride_diff,
+                            (function()
+                                local parts = {}
+                                for _, item in ipairs(strides) do
+                                    table.insert(parts, string.format("x=%d stride=%.1f n=%d first_y=%s",
+                                        item.x, item.stride, item.n, item.first_y or "nil"))
+                                end
+                                return table.concat(parts, ", ")
+                            end)()))
+                end
+            end
+            if checked == 0 then
+                pending("Need at least one indented content column")
+            end
+        end)
+
+        it("ruby base sboxes are not collapsed at the column bottom", function()
+            local screen_w, screen_h = Screen:getWidth(), Screen:getHeight()
+            local targets = { ["蝶"] = true, ["花"] = true, ["鳥"] = true }
+            local found = {}
+            local seen = {}
+            for x = screen_w - 10, 10, -10 do
+                for y = 5, screen_h - 5, 4 do
+                    local ok, word = pcall(function()
+                        return doc:getWordFromPosition({x=x, y=y})
+                    end)
+                    if ok and word and word.word and word.sbox and targets[word.word] then
+                        local sb = word.sbox
+                        local key = string.format("%s:%d:%d:%d:%d", word.word, sb.x, sb.y, sb.w, sb.h)
+                        if not seen[key] then
+                            seen[key] = true
+                            if sb.h > 0 then
+                                found[word.word] = {x=sb.x, y=sb.y, w=sb.w, h=sb.h}
+                            end
                         end
-                        return table.concat(parts, ", ")
-                    end)()))
+                    end
+                end
+            end
+
+            local parts = {}
+            for ruby_base in pairs(targets) do
+                local sb = found[ruby_base]
+                assert.truthy(sb, "No non-collapsed sbox found for ruby base " .. ruby_base)
+                table.insert(parts, string.format("%s@x%d/y%d/h%d", ruby_base, sb.x, sb.y, sb.h))
+                assert.truthy(sb.h >= 16 and sb.h <= 30,
+                    string.format("Unexpected ruby base height for %s: %s", ruby_base, sb.h))
+                assert.truthy(sb.y < screen_h - 40,
+                    string.format("Ruby base %s collapsed near bottom: %s", ruby_base, table.concat(parts, ", ")))
+            end
         end)
     end)
 

--- a/spec/unit/vertical_jfm_justify_spec.lua
+++ b/spec/unit/vertical_jfm_justify_spec.lua
@@ -1,0 +1,175 @@
+--[[--
+Vertical text: JFM-based justification.
+
+This checks the fork-only vertical post-pass that applies LuaTeX-ja/JFM
+base glue and justify stretch/shrink to word->x. It intentionally uses sboxes
+instead of screenshot pixels so it can run in the existing unit environment.
+--]]
+
+describe("Vertical text JFM justify #vertical_jfm_justify", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local html_path = "/tmp/koreader_vertical_jfm_justify.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI         = require("apps/reader/readerui")
+        Screen           = require("device").screen
+        UIManager        = require("ui/uimanager")
+    end)
+
+    local function apply_css(readerui, text_align_last)
+        readerui.styletweak.book_style_tweak =
+            "body { writing-mode: vertical-rl !important; text-align: justify !important; " ..
+            "text-align-last: " .. text_align_last .. " !important; } " ..
+            "p, li { text-align: justify !important; }"
+        readerui.styletweak.book_style_tweak_enabled = true
+        readerui.styletweak:updateCssText(true)
+        fastforward_ui_events()
+    end
+
+    local function ensure_html_fixture()
+        local phrase =
+            "これは縦組み本文の均等配置を確認するための長い本文です。「句読点」、中点・疑問符？！を含めても、非最終列は自然に末端まで届きます。"
+        local body = {}
+        for _ = 1, 180 do table.insert(body, phrase) end
+        local html = [[<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta charset="UTF-8"/>
+<title>vertical jfm justify</title>
+<style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; text-align: justify; font-family: serif; }
+p { margin: 0; text-align: justify; }
+</style>
+</head>
+<body><p>]] .. table.concat(body) .. [[</p></body>
+</html>]]
+        local f = assert(io.open(html_path, "wb"))
+        f:write(html)
+        f:close()
+        return html_path
+    end
+
+    local function get_word_at(doc, x, y)
+        local ok, w = pcall(function()
+            return doc:getWordFromPosition({x = x, y = y})
+        end)
+        if ok and w and w.word and #w.word > 0 and w.sbox then return w end
+        return nil
+    end
+
+    local function collect_columns(doc)
+        local sw, sh = Screen:getWidth(), Screen:getHeight()
+        local step_x = math.max(5, math.floor(sw / 70))
+        local step_y = math.max(4, math.floor(sh / 130))
+        local seen, words, em_samples = {}, {}, {}
+        for x = sw - 4, 4, -step_x do
+            for y = 4, sh - 4, step_y do
+                local word = get_word_at(doc, x, y)
+                if word then
+                    local key = string.format("%d_%d_%s", word.sbox.x, word.sbox.y, word.word)
+                    if not seen[key] then
+                        seen[key] = true
+                        table.insert(words, word)
+                        if word.sbox.h >= 8 and word.sbox.h <= 80 then
+                            table.insert(em_samples, word.sbox.h)
+                        end
+                    end
+                end
+            end
+        end
+        table.sort(em_samples)
+        local em = em_samples[math.max(1, math.floor(#em_samples / 2))] or 26
+        local function col_key(word)
+            return math.floor((word.sbox.x + word.sbox.w / 2) / math.max(1, em))
+        end
+        local columns = {}
+        for _, word in ipairs(words) do
+            local k = col_key(word)
+            local sb = word.sbox
+            local c = columns[k] or {count = 0, top = math.huge, bottom = 0, x = sb.x}
+            c.count = c.count + 1
+            c.top = math.min(c.top, sb.y)
+            c.bottom = math.max(c.bottom, sb.y + math.max(sb.h, em))
+            columns[k] = c
+        end
+        local list = {}
+        for _, c in pairs(columns) do table.insert(list, c) end
+        table.sort(list, function(a, b) return a.x > b.x end)
+        return list, em
+    end
+
+    local function open_reader()
+        local path = ensure_html_fixture()
+        local readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(path),
+        }
+        UIManager:show(readerui)
+        readerui.document:setFontSize(26)
+        return readerui
+    end
+
+    it("justifies non-final CJK columns to within 2px of the page bottom", function()
+        local readerui = open_reader()
+        apply_css(readerui, "auto")
+        readerui.rolling:onGotoPage(1)
+        fastforward_ui_events()
+
+        local columns, em = collect_columns(readerui.document)
+        readerui:onClose()
+        UIManager:quit()
+
+        if #columns < 4 then pending("not enough columns found"); return end
+        local page_bottom = 0
+        for _, c in ipairs(columns) do page_bottom = math.max(page_bottom, c.bottom) end
+        local full_count_min = math.max(8, math.floor(page_bottom / math.max(1, em)) - 2)
+        local checked, best_shortfall = 0, math.huge
+        for _, c in ipairs(columns) do
+            local shortfall = page_bottom - c.bottom
+            if c.count >= full_count_min and c.bottom > Screen:getHeight() * 0.70 then
+                checked = checked + 1
+                best_shortfall = math.min(best_shortfall, shortfall)
+                print(string.format(
+                    "[vertical_jfm_justify] x=%d count=%d bottom=%d page_bottom=%d shortfall=%d em=%d",
+                    c.x, c.count, c.bottom, page_bottom, shortfall, em))
+            end
+        end
+        if checked < 2 then pending("not enough full non-final columns found"); return end
+        assert.truthy(best_shortfall <= 2,
+            string.format("best full-column shortfall=%dpx; expected <=2px", best_shortfall))
+    end)
+
+    it("keeps text-align-last:auto ragged but allows text-align-last:justify", function()
+        local function last_column_shortfall(text_align_last)
+            local readerui = open_reader()
+            if not readerui then return nil end
+            apply_css(readerui, text_align_last)
+            readerui.rolling:onGotoPage(readerui.document:getPageCount())
+            fastforward_ui_events()
+            local columns = collect_columns(readerui.document)
+            readerui:onClose()
+            UIManager:quit()
+            if #columns < 2 then return nil end
+            local page_bottom = 0
+            for _, c in ipairs(columns) do page_bottom = math.max(page_bottom, c.bottom) end
+            table.sort(columns, function(a, b) return a.count < b.count end)
+            return page_bottom - columns[1].bottom
+        end
+        local auto_shortfall = last_column_shortfall("auto")
+        local justify_shortfall = last_column_shortfall("justify")
+        if not auto_shortfall or not justify_shortfall then
+            pending("not enough columns on final page")
+            return
+        end
+        print(string.format("[vertical_jfm_justify] text-align-last auto=%d justify=%d",
+            auto_shortfall, justify_shortfall))
+        assert.truthy(auto_shortfall > justify_shortfall + 4,
+            string.format("auto=%d justify=%d", auto_shortfall, justify_shortfall))
+    end)
+end)

--- a/spec/unit/vertical_latin_ruby_advance_spec.lua
+++ b/spec/unit/vertical_latin_ruby_advance_spec.lua
@@ -96,4 +96,44 @@ describe("Vertical text: Latin ruby uses horizontal advance #latin_ruby_advance"
                 .. "in measureText() (base_horiz_advance_pre path) is not active.",
                 total_px))
     end)
+
+    it("rp fallback text is ignored when measuring annotation depth #latin_rp_advance", function()
+        local rp_epub = "spec/front/unit/data/fixtures/vertical_text/ruby_rp_latin.epub"
+        if not lfs.attributes(rp_epub) then
+            pending("ruby_rp_latin.epub not found")
+            return
+        end
+
+        local before_total = doc and doc._document and doc._document:getVertRubyAdvDiff() or 0
+        if readerui then readerui:onClose() end
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(rp_epub),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        doc = readerui.document
+
+        local pages_to_visit = math.min(doc:getPageCount(), 5)
+        for pg = 1, pages_to_visit do
+            readerui.rolling:onGotoPage(pg)
+            fastforward_ui_events()
+        end
+
+        local total_px, max_px = doc._document:getVertRubyAdvDiff()
+        local delta_px = total_px - before_total
+
+        print(string.format(
+            "[latin_rp_advance] pages=%d  adv_diff_delta=%d px  adv_diff_total=%d px  adv_diff_max=%d px",
+            pages_to_visit, delta_px, total_px, max_px))
+
+        assert.is_true(delta_px > 0,
+            string.format(
+                "render_w - advance diff delta is %d px (expected > 0). "
+                .. "The <rp> fallback parentheses were likely counted as visible "
+                .. "ruby annotation text, making annot_depth dominate the ruby "
+                .. "inline-box advance.  Ignore el_rp when measuring vertical "
+                .. "ruby annotation depth.",
+                delta_px))
+    end)
 end)

--- a/spec/unit/vertical_line_spacing_spec.lua
+++ b/spec/unit/vertical_line_spacing_spec.lua
@@ -1,0 +1,91 @@
+--[[--
+Vertical-rl default line spacing.
+
+The fork maps the ordinary horizontal 100% line spacing setting to a wider
+vertical-rl line pitch when the book leaves line-height at normal. Explicit
+publisher line-height values must remain under CSS control.
+--]]
+
+describe("Vertical line spacing #vertical_line_spacing", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function write_fixture(path, extra_css)
+        local body = {}
+        for _ = 1, 180 do
+            table.insert(body, "これは縦組み行間の確認です。")
+        end
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head><meta charset="UTF-8"/><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; text-align: justify; font-family: serif; ]] .. extra_css .. [[ }
+p { margin: 0; }
+</style></head><body><p>]], table.concat(body), [[</p></body></html>]])
+        f:close()
+    end
+
+    local function median_column_gap(path)
+        local readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(path),
+        }
+        UIManager:show(readerui)
+        readerui.document:setFontSize(26)
+        readerui.document:setInterlineSpacePercent(100)
+        readerui.rolling:onGotoPage(1)
+        fastforward_ui_events()
+
+        local cols = {}
+        for x = Screen:getWidth() - 5, 5, -8 do
+            for y = 20, Screen:getHeight() - 20, 24 do
+                local ok, w = pcall(function()
+                    return readerui.document:getWordFromPosition({x = x, y = y})
+                end)
+                if ok and w and w.word and w.sbox and w.sbox.w >= 10 and w.sbox.w <= 90 then
+                    local cx = math.floor(w.sbox.x + w.sbox.w / 2 + 0.5)
+                    cols[cx] = true
+                end
+            end
+        end
+        local list = {}
+        for x in pairs(cols) do table.insert(list, x) end
+        table.sort(list, function(a, b) return a > b end)
+        local gaps = {}
+        for i = 1, #list - 1 do
+            local d = list[i] - list[i + 1]
+            if d >= 10 and d <= 100 then table.insert(gaps, d) end
+        end
+        table.sort(gaps)
+        local median = gaps[math.max(1, math.floor(#gaps / 2))] or 0
+        readerui:onClose()
+        UIManager:quit()
+        return median, #list
+    end
+
+    it("adds vertical-rl default pitch only for normal line-height", function()
+        local normal_path = "/tmp/koreader_vertical_line_spacing_normal.xhtml"
+        local explicit_path = "/tmp/koreader_vertical_line_spacing_explicit.xhtml"
+        write_fixture(normal_path, "")
+        write_fixture(explicit_path, "line-height: 1;")
+
+        local normal_gap, normal_cols = median_column_gap(normal_path)
+        local explicit_gap, explicit_cols = median_column_gap(explicit_path)
+        print(string.format(
+            "[vertical_line_spacing] normal_gap=%d explicit_gap=%d normal_cols=%d explicit_cols=%d",
+            normal_gap, explicit_gap, normal_cols, explicit_cols))
+
+        assert.is_true(normal_gap >= explicit_gap + 10,
+            string.format("normal vertical-rl gap %d should exceed explicit line-height gap %d", normal_gap, explicit_gap))
+    end)
+end)

--- a/spec/unit/vertical_text_spec.lua
+++ b/spec/unit/vertical_text_spec.lua
@@ -132,7 +132,32 @@ describe("Vertical text", function()
             -- The core invariant: tap → word → sbox should contain ~the tap point.
             -- In vertical-rl, docToWindowPoint may be off by ~left_margin (≈9px).
             local tol = 60  -- generous tolerance for margin offsets
-            local x, y, word, sb = find_any_content(doc)
+            local x, y, word, sb
+            local first_x, first_y, first_word, first_sb
+            local w, h = Screen:getWidth(), Screen:getHeight()
+            for _, y_frac in ipairs({0.3, 0.5, 0.2, 0.7}) do
+                local yy = math.floor(h * y_frac)
+                local xs = find_content_columns(doc, yy, 1)
+                if xs then
+                    for _, xx in ipairs(xs) do
+                        local ok, ww = pcall(function()
+                            return doc:getWordFromPosition({x=xx, y=yy})
+                        end)
+                        if ok and ww and ww.word and ww.sbox then
+                            first_x, first_y, first_word, first_sb =
+                                first_x or xx, first_y or yy, first_word or ww, first_sb or ww.sbox
+                            local ssb = ww.sbox
+                            if ssb.x - tol <= xx and xx <= ssb.x + ssb.w + tol
+                                    and ssb.y - tol <= yy and yy <= ssb.y + ssb.h + tol then
+                                x, y, word, sb = xx, yy, ww, ssb
+                                break
+                            end
+                        end
+                    end
+                end
+                if sb then break end
+            end
+            x, y, word, sb = x or first_x, y or first_y, word or first_word, sb or first_sb
             assert.truthy(sb, "No word/sbox found on page")
             assert.truthy(
                 sb.x - tol <= x and x <= sb.x + sb.w + tol,


### PR DESCRIPTION
## Summary

Fix vertical ruby metrics so `<rp>` fallback text is not counted as visible annotation text.

In ruby-capable renderers, `<rp>` content is fallback punctuation for non-ruby environments and should not contribute to annotation character count, annotation depth, or vertical inline-box advance.

This keeps `<rp>` in ruby structure/boxing detection, but skips `el_rp` and invisible nodes when collecting visible ruby annotation metrics.

## Background

Follow-up from #23. The attached Kakuyomu EPUB uses markup such as:

```html
<ruby>使<rp>（</rp><rt>つか</rt><rp>）</rp></ruby>
```

Temporary instrumentation showed the current metrics path counting annotation text as `（つか）` instead of `つか`, inflating ruby inline-box depth.

## Changes

- Add visible-ruby-annotation metric collection in crengine vertical text layout.
- Ignore `el_rp` and invisible ruby nodes for annotation depth/character count.
- Add a regression fixture with Latin-base ruby and `<rp>` fallback punctuation.
- Extend the vertical Latin ruby advance spec for the `<rp>` case.

## Tests

```bash
nix develop --command bash -lc './kodev test front --busted -- spec/front/unit/vertical_latin_ruby_advance_spec.lua'
nix develop --command bash -lc './kodev test front --busted -- spec/front/unit/vertical_ruby_space_gap_spec.lua spec/front/unit/vertical_ruby_column_spec.lua spec/front/unit/ruby_annot_y_spec.lua spec/front/unit/vertical_text_spec.lua'
```
## Additional notes:

This PR also includes the vertical JFM-based justification work. In vertical CJK text, non-final justified columns should now reach the bottom of the available page area instead of ending short.

It also includes related vertical rendering fixes for CSS decorations and layout effects, including backgrounds and image/page-split handling in vertical writing mode.