### PR TITLE
Add vertical CSS layout regressions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,29 @@
           "lua_cliargs"
         ];
 
+        koreaderBuild = pkgs.writeShellScriptBin "koreader-build" ''
+          exec make -C base "$@"
+        '';
+        koreaderRun = pkgs.writeShellScriptBin "koreader-run" ''
+          exec make run "$@"
+        '';
+        koreaderTestBase = pkgs.writeShellScriptBin "koreader-test-base" ''
+          exec base/test-runner/runtests "$@"
+        '';
+        koreaderTestFront = pkgs.writeShellScriptBin "koreader-test-front" ''
+          exec make testfront "$@"
+        '';
+        koreaderTestVertical = pkgs.writeShellScriptBin "koreader-test-vertical" ''
+          exec test/test-vertical.sh "$@"
+        '';
+        koreaderScreenshotCompare = pkgs.writeShellScriptBin "koreader-screenshot-compare" ''
+          exec test/test-vertical.sh compare "$@"
+        '';
+        koreaderCreateEpub = pkgs.writeShellScriptBin "koreader-create-epub" ''
+          exec python3 base/tests/fixtures/vertical_text/create-epub.py \
+            base/tests/fixtures/vertical_text/simple_ja_noruby.epub "$@"
+        '';
+
       in
       {
         devShells.default = pkgs.mkShell {
@@ -46,6 +69,8 @@
             luajitPackages.luacheck
             shellcheck shfmt
             zip
+            koreaderBuild koreaderRun koreaderTestBase koreaderTestFront
+            koreaderTestVertical koreaderScreenshotCompare koreaderCreateEpub
             # CI lint tools (crengine/.github/workflows/build.yml runs clang-tidy + cppcheck)
             clang-tools cppcheck
             # System libs needed for crengine lint to resolve includes via pkg-config
@@ -64,17 +89,9 @@
           shellHook = ''
             export LD_LIBRARY_PATH="${pkgs.sdl3}/lib:${pkgs.libGL}/lib:${pkgs.libusb1}/lib:$LD_LIBRARY_PATH"
 
-            alias koreader-build='make -C base'
-            alias koreader-run='make -C base run'
-            alias koreader-test-base='base/test-runner/runtests'
-            alias koreader-test-front='make testfront'
-            alias koreader-test-vertical='test/test-vertical.sh'
-            alias koreader-screenshot-compare='test/test-vertical.sh compare'
-            alias koreader-create-epub='python3 base/tests/fixtures/vertical_text/create-epub.py base/tests/fixtures/vertical_text/simple_ja_noruby.epub'
-
             echo "KOReader dev shell ready."
             echo "  koreader-build          — build emulator (make -C base)"
-            echo "  koreader-run            — run emulator (make -C base run)"
+            echo "  koreader-run            — run emulator (make run)"
             echo "  koreader-test-base      — run base/ unit tests"
             echo "  koreader-test-front     — run frontend unit tests"
             echo "  koreader-test-vertical  — run vertical text screenshot tests"

--- a/spec/unit/vertical_fullwidth_border_spec.lua
+++ b/spec/unit/vertical_fullwidth_border_spec.lua
@@ -1,0 +1,83 @@
+--[[--
+Vertical inline borders next to upright fullwidth text.
+
+The text decoration belongs to the anchor's inline box. A descendant fullwidth
+digit may have a larger font, but it must not move only its portion of the
+decoration or the coincident border-right line.
+--]]
+
+describe("Vertical text: fullwidth inline border #vertical_fullwidth_border", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local path = "/tmp/koreader_vertical_fullwidth_border.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    it("draws an underlined bordered link without treating padding as text", function()
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 48px; }
+p { margin: 1em; }
+a { border-right: 2px solid; text-decoration: underline; }
+a span { font-size: 1.66667em; }
+</style></head><body><p><a href="#">第<span>１</span>章</a></p></body></html>]])
+        f:close()
+
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(path),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local words = {}
+        for x = Screen:getWidth() - 4, 4, -4 do
+            for y = 4, Screen:getHeight() - 4, 4 do
+                local word = readerui.document:getWordFromPosition({x=x, y=y})
+                if word and word.sbox
+                        and (word.word == "第" or word.word == "１" or word.word == "章") then
+                    words[word.word] = word.sbox
+                end
+            end
+        end
+        local found = assert(words["１"], "fullwidth digit was not rendered")
+        print(string.format("[vertical_fullwidth_border] digit=(%d,%d %dx%d)",
+            found.x, found.y, found.w, found.h))
+
+        local first = assert(words["第"], "first anchor character was not rendered")
+        local last = assert(words["章"], "last anchor character was not rendered")
+        local y0 = math.min(first.y, found.y, last.y)
+        local y1 = math.max(first.y + first.h, found.y + found.h, last.y + last.h)
+        local span = y1 - y0
+        local continuous_columns = {}
+        for x = 0, Screen:getWidth() - 1 do
+            local dark = 0
+            for y = y0, y1 - 1 do
+                local px = Screen.bb:getPixel(x, y)
+                if px and px:getR() < 200 then dark = dark + 1 end
+            end
+            if dark >= span * 0.8 then
+                table.insert(continuous_columns, x)
+            end
+        end
+        print(string.format("[vertical_fullwidth_border] continuous_line_columns=%s",
+            table.concat(continuous_columns, ",")))
+        assert.is_true(#continuous_columns >= 1, "vertical decoration line was not continuous")
+        assert.is_true(#continuous_columns <= 3,
+            "underline and border-right separated into an abnormally wide/double line")
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)

--- a/spec/unit/vertical_inline_image_spec.lua
+++ b/spec/unit/vertical_inline_image_spec.lua
@@ -60,4 +60,43 @@ describe("Vertical text: inline image placement", function()
         assert.are.equal(0, drift_count,
             string.format("vertical inline image draw Y drifted from layout position (worst: %d px)", max_px))
     end)
+
+    it("reserves the physical width of a wide image mixed with text #inline_image", function()
+        if not lfs.attributes(epub_path) then
+            pending("inline_image_test.epub fixture missing")
+            return
+        end
+
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(epub_path),
+        }
+        doc = readerui.document
+        readerui.styletweak.book_style_tweak =
+            "img.mark { width: 5em !important; height: 2em !important; }"
+        readerui.styletweak.book_style_tweak_enabled = true
+        readerui.styletweak:updateCssText(true)
+        doc._document:resetVertImageDrawDrift()
+        doc._document:resetVertImageCrossUnderreserve()
+        doc._document:resetVertMixedImageAxis()
+
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        readerui.rolling:onGotoPage(1)
+        fastforward_ui_events()
+
+        local count, max_px = doc._document:getVertImageCrossUnderreserve()
+        local draw_count = doc._document:getVertImageDrawDrift()
+        local axis_samples, axis_drift, axis_max_px = doc._document:getVertMixedImageAxis()
+        print(string.format("[inline_image_cross_extent] underreserve_count=%d max_px=%d",
+            count, max_px))
+        print(string.format("[inline_image_axis] samples=%d drift_count=%d max_px=%d",
+            axis_samples, axis_drift, axis_max_px))
+        assert.is_true(draw_count > 0, "fixture did not draw a vertical inline image")
+        assert.is_true(axis_samples > 0, "fixture did not draw CJK in an image-widened line")
+        assert.are.equal(0, count,
+            string.format("vertical mixed-content line under-reserved image width (worst: %d px)", max_px))
+        assert.are.equal(0, axis_drift,
+            string.format("vertical CJK drifted from the image column axis (worst: %d px)", axis_max_px))
+    end)
 end)

--- a/spec/unit/vertical_negative_text_indent_spec.lua
+++ b/spec/unit/vertical_negative_text_indent_spec.lua
@@ -1,0 +1,118 @@
+--[[--
+Vertical text: negative text-indent follows the CSS inline axis.
+
+Publishers commonly pair padding-top with an equal negative text-indent to
+pull only the first formatted line into the reserved area.  The regression
+used the sign of text-indent as an internal `hanging` marker, moving every
+line except the first instead.  Assert on document geometry, not pixels.
+--]]
+
+describe("Vertical text: negative first-line indent #vertical_negative_indent", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local html_path = "/tmp/koreader_vertical_negative_text_indent_v2.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function fixture()
+        local f = assert(io.open(html_path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 32px; }
+p { margin: 0; padding-top: 5em; text-indent: 1.2em; -cr-hint: default-text-indent; }
+div { margin: 0 1em; }
+.outdent { text-indent: -5em; }
+</style></head><body>
+<div class="outdent"><p>ALPHA</p></div><div><p>BRAVO</p></div>
+</body></html>]])
+        f:close()
+        return html_path
+    end
+
+    local function horizontal_fixture()
+        local path = "/tmp/koreader_horizontal_negative_text_indent.xhtml"
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { font-size: 32px; }
+p { margin: 1em 0; padding-left: 5em; text-indent: 1.2em; -cr-hint: default-text-indent; }
+.outdent { text-indent: -5em; }
+</style></head><body>
+<div class="outdent"><p>ALPHA</p></div><div><p>BRAVO</p></div>
+</body></html>]])
+        f:close()
+        return path
+    end
+
+    local function find_word(doc, target)
+        local seen = {}
+        for x = Screen:getWidth() - 4, 4, -4 do
+            for y = 2, Screen:getHeight() - 2, 3 do
+                local word = doc:getWordFromPosition({ x = x, y = y })
+                if word and word.word == target and word.sbox then
+                    local sb = word.sbox
+                    local key = string.format("%d:%d:%d:%d", sb.x, sb.y, sb.w, sb.h)
+                    seen[key] = { x = sb.x, y = sb.y, w = sb.w, h = sb.h }
+                end
+            end
+        end
+        for _, sb in pairs(seen) do return sb end
+    end
+
+    it("applies a negative length to the first formatted column only", function()
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(fixture()),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local alpha = assert(find_word(readerui.document, "ALPHA"), "outdented word missing")
+        local bravo = assert(find_word(readerui.document, "BRAVO"), "control word missing")
+        local delta = bravo.y - alpha.y
+        print(string.format(
+            "[vertical_negative_indent] outdent=(%d,%d %dx%d) control=(%d,%d %dx%d) delta_y=%d",
+            alpha.x, alpha.y, alpha.w, alpha.h,
+            bravo.x, bravo.y, bravo.w, bravo.h, delta))
+
+        assert.is_true(delta >= 4 * 32,
+            string.format("negative 5em first-line indent moved only %dpx", delta))
+
+        readerui:onClose()
+        readerui = nil
+    end)
+
+    it("uses the same signed first-line semantics in horizontal writing", function()
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(horizontal_fixture()),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local alpha = assert(find_word(readerui.document, "ALPHA"), "horizontal outdented word missing")
+        local bravo = assert(find_word(readerui.document, "BRAVO"), "horizontal control word missing")
+        local delta = bravo.x - alpha.x
+        print(string.format(
+            "[horizontal_negative_indent] outdent=(%d,%d %dx%d) control=(%d,%d %dx%d) delta_x=%d",
+            alpha.x, alpha.y, alpha.w, alpha.h,
+            bravo.x, bravo.y, bravo.w, bravo.h, delta))
+
+        assert.is_true(delta >= 4 * 32,
+            string.format("horizontal negative 5em first-line indent moved only %dpx", delta))
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)

--- a/spec/unit/vertical_tcy_digits_spec.lua
+++ b/spec/unit/vertical_tcy_digits_spec.lua
@@ -1,0 +1,93 @@
+--[[--
+Vertical text: text-combine-upright digit limits.
+
+CSS `digits N` combines only ASCII digit runs of N characters or fewer.  It
+must not turn a longer number or non-digit text into tate-chu-yoko.  Geometry
+from getWordFromPosition is the observable layout contract: a TCY run occupies
+one em slot, while a longer rotated run occupies several ems.
+--]]
+
+describe("Vertical text: tate-chu-yoko digit limits #tcy_digits", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local html_path = "/tmp/koreader_vertical_tcy_digits.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function fixture()
+        local f = assert(io.open(html_path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+body { writing-mode: vertical-rl; font-size: 32px; margin: 0; }
+p { margin: 0 1em 0 0; }
+.d2 { text-combine-upright: digits 2; }
+.d3 { text-combine-upright: digits 3; }
+</style></head><body>
+<p>甲<span class="d2">12</span>乙</p>
+<p>丙<span class="d2">123</span>丁</p>
+<p>戊<span class="d3">123</span>己</p>
+<p>庚<span class="d2">AB</span>辛</p>
+</body></html>]])
+        f:close()
+        return html_path
+    end
+
+    local function find_word(doc, target)
+        local seen = {}
+        for x = Screen:getWidth() - 4, 4, -4 do
+            for y = 4, Screen:getHeight() - 4, 4 do
+                local word = doc:getWordFromPosition({ x = x, y = y })
+                if word and word.word == target and word.sbox then
+                    local sb = word.sbox
+                    local key = string.format("%d:%d:%d:%d", sb.x, sb.y, sb.w, sb.h)
+                    if not seen[key] then
+                        seen[key] = { x = sb.x, y = sb.y, w = sb.w, h = sb.h }
+                    end
+                end
+            end
+        end
+        local found = {}
+        for _, sb in pairs(seen) do table.insert(found, sb) end
+        table.sort(found, function(a, b) return a.x > b.x end)
+        return found
+    end
+
+    it("honours digits 2 and digits 3 without combining non-digits", function()
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(fixture()),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        local doc = readerui.document
+        local two = assert(find_word(doc, "12")[1], "digits 2 run missing")
+        local threes = find_word(doc, "123")
+        local long = assert(threes[1], "digits 2 three-digit run missing")
+        local letter = assert(find_word(doc, "AB")[1], "non-digit run missing")
+        local combined_three = assert(threes[2], "digits 3 run missing")
+        local d2_next = assert(find_word(doc, "丁")[1], "digits 2 following character missing")
+        local d3_next = assert(find_word(doc, "己")[1], "digits 3 following character missing")
+        print(string.format("[tcy_digits] 12=%dx%d 123(d2)=%dx%d 123(d3)=%dx%d AB=%dx%d",
+            two.w, two.h, long.w, long.h,
+            combined_three.w, combined_three.h, letter.w, letter.h))
+        print(string.format("[tcy_digits] d2=(%d,%d)->丁(%d,%d) d3=(%d,%d)->己(%d,%d)",
+            long.x, long.y, d2_next.x, d2_next.y,
+            combined_three.x, combined_three.y, d3_next.x, d3_next.y))
+        assert.is_true(two.h < long.h, "digits 2 must not combine a three-digit run")
+        assert.is_true(d3_next.y - combined_three.y < d2_next.y - long.y,
+            "digits 3 must advance less than an uncombined three-digit run")
+        assert.is_true(letter.h > two.h, "digits must not combine non-digit text")
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)


### PR DESCRIPTION
## What changed

- update `base` to the merged vertical layout diagnostics and crengine fixes
- add log-driven regression coverage for vertical decoration ownership, fullwidth numerals, signed text indent, TCY digit limits, and mixed inline-image geometry
- make the flake development commands real executable packages so `nix develop -c koreader-run` and the test aliases work non-interactively

## Root cause covered

Vertical layout and paint previously disagreed about logical/physical axes, inherited indentation, decoration ownership, and used inline/cross extents. The new tests assert engine geometry and pixel continuity rather than relying only on visual inspection.

## Validation

- based on the latest synchronized `origin/master`
- crengine PR #2 merged
- koreader-base PR #2 merged
- `nix develop --no-write-lock-file -c koreader-build`
- targeted layout regressions: 6/6 passed
- `nix develop --no-write-lock-file -c koreader-test-vertical`: 21/21 passed
- `nix flake check --no-write-lock-file --no-build`
- `git diff --check`