### PR TITLE
Fix ComicInfo RTL page direction detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ Japanese manga EPUBs and CBZ/CBR files with right-to-left page order are detecte
 automatically when you open them for the first time:
 
 - **EPUB**: reads `page-progression-direction="rtl"` from the OPF spine
-- **CBZ/CBR**: reads `<ReadingDirection>RTL</ReadingDirection>` from `ComicInfo.xml`
+- **CBZ/CBR**: reads the standard
+  `<Manga>YesAndRightToLeft</Manga>` value from `ComicInfo.xml`
+  (`<ReadingDirection>RTL</ReadingDirection>` and `RightToLeft` are also
+  accepted for compatibility)
 
 When RTL is detected a notification appears, the page-turn direction is reversed,
 and the progress bar fills from right (page 1) to left (last page).
@@ -212,7 +215,9 @@ body { writing-mode: vertical-rl !important; }
 初回オープン時に自動検出されます:
 
 - **EPUB**: OPF spine の `page-progression-direction="rtl"` を読み取り
-- **CBZ/CBR**: `ComicInfo.xml` の `<ReadingDirection>RTL</ReadingDirection>` を読み取り
+- **CBZ/CBR**: `ComicInfo.xml` の標準指定
+  `<Manga>YesAndRightToLeft</Manga>` を読み取り
+  （互換性のため `<ReadingDirection>RTL</ReadingDirection>` と `RightToLeft` にも対応）
 
 RTL が検出されると通知が表示され、ページめくり方向が反転し、進捗バーは右
 （1 ページ目）から左（最終ページ）に進みます。

--- a/frontend/apps/reader/modules/reader_auto_direction.lua
+++ b/frontend/apps/reader/modules/reader_auto_direction.lua
@@ -16,6 +16,7 @@ view state set by ReaderView is already available.
 
 local BD = require("ui/bidi")
 local EventListener = require("ui/widget/eventlistener")
+local logger = require("logger")
 local Notification = require("ui/widget/notification")
 local _ = require("gettext")
 
@@ -23,25 +24,33 @@ local ReaderAutoDirection = EventListener:extend{}
 ReaderAutoDirection.DETECTION_VERSION = 2
 
 function ReaderAutoDirection:onReadSettings(config)
-    local detected_version = tonumber(config:readSetting("direction_auto_detected_version")) or 0
-    if detected_version >= self.DETECTION_VERSION then return end
-
-    local has_legacy_detection = config:has("direction_auto_detected")
-
-    -- A per-document direction that predates auto-detection is an established
-    -- user choice. Legacy auto-detection entries are safe to migrate: their
-    -- marker lets us distinguish them from such pre-existing settings.
-    if not has_legacy_detection and config:has("inverse_reading_order") then
+    -- inverse_reading_order is serialized for every document on close, even
+    -- when it only contains the default value. Only this explicit marker can
+    -- distinguish a user override from such an automatically saved default.
+    if config:isTrue("page_direction_user_override") then
+        logger.dbg("ReaderAutoDirection: preserving explicit user override for", self.document.file)
         return
     end
 
+    local detected_version = tonumber(config:readSetting("direction_auto_detected_version")) or 0
+    if detected_version >= self.DETECTION_VERSION then
+        logger.dbg("ReaderAutoDirection: current detection already recorded for", self.document.file)
+        return
+    end
+
+    local has_legacy_detection = config:has("direction_auto_detected")
+
     -- Global RTL default already in effect – nothing to do.
-    if not has_legacy_detection and self.view.inverse_reading_order then return end
+    if not has_legacy_detection and self.view.inverse_reading_order then
+        logger.dbg("ReaderAutoDirection: global RTL default already applies to", self.document.file)
+        return
+    end
 
     local ok, PageDirection = pcall(require, "util/page_direction")
     if not ok then return end
 
     local dir = PageDirection.getDirection(self.document)
+    logger.dbg("ReaderAutoDirection: detected", dir, "for", self.document.file)
 
     -- Mark detection as done regardless of outcome so we don't re-scan on
     -- every open. The version lets corrected detectors revisit only results

--- a/frontend/apps/reader/modules/reader_auto_direction.lua
+++ b/frontend/apps/reader/modules/reader_auto_direction.lua
@@ -5,7 +5,8 @@ applies it to the reader view when the user has not made an explicit choice.
 Supported sources:
 - EPUB: `page-progression-direction` attribute on the OPF `<spine>` element
   (stored in document props by crengine's epubfmt.cpp, exposed via cre.cpp)
-- CBZ/CBR/CBT: `<ReadingDirection>` element inside ComicInfo.xml
+- CBZ/CBR/CBT: `<Manga>YesAndRightToLeft</Manga>` inside ComicInfo.xml,
+  with `<ReadingDirection>` accepted for compatibility
 
 This module is intentionally separate from ReaderView so that upstream
 merges to readerview.lua do not conflict with fork-specific detection logic.
@@ -19,16 +20,23 @@ local Notification = require("ui/widget/notification")
 local _ = require("gettext")
 
 local ReaderAutoDirection = EventListener:extend{}
+ReaderAutoDirection.DETECTION_VERSION = 2
 
 function ReaderAutoDirection:onReadSettings(config)
-    -- "direction_auto_detected" is written the first time we successfully detect
-    -- a direction for this document.  Once set, we defer entirely to whatever
-    -- inverse_reading_order the user (or the previous auto-run) left behind.
-    -- This avoids re-detecting on every open while still letting the user override.
-    if config:has("direction_auto_detected") then return end
+    local detected_version = tonumber(config:readSetting("direction_auto_detected_version")) or 0
+    if detected_version >= self.DETECTION_VERSION then return end
+
+    local has_legacy_detection = config:has("direction_auto_detected")
+
+    -- A per-document direction that predates auto-detection is an established
+    -- user choice. Legacy auto-detection entries are safe to migrate: their
+    -- marker lets us distinguish them from such pre-existing settings.
+    if not has_legacy_detection and config:has("inverse_reading_order") then
+        return
+    end
 
     -- Global RTL default already in effect – nothing to do.
-    if self.view.inverse_reading_order then return end
+    if not has_legacy_detection and self.view.inverse_reading_order then return end
 
     local ok, PageDirection = pcall(require, "util/page_direction")
     if not ok then return end
@@ -36,8 +44,10 @@ function ReaderAutoDirection:onReadSettings(config)
     local dir = PageDirection.getDirection(self.document)
 
     -- Mark detection as done regardless of outcome so we don't re-scan on
-    -- every open (the result is stored in inverse_reading_order itself).
+    -- every open. The version lets corrected detectors revisit only results
+    -- produced by an older implementation.
     config:saveSetting("direction_auto_detected", dir or "none")
+    config:saveSetting("direction_auto_detected_version", self.DETECTION_VERSION)
 
     if dir ~= "rtl" then return end
 

--- a/frontend/apps/reader/modules/reader_auto_direction.lua
+++ b/frontend/apps/reader/modules/reader_auto_direction.lua
@@ -64,7 +64,7 @@ function ReaderAutoDirection:onReadSettings(config)
     -- ReaderView:onReadSettings ran first and set the bar for the non-detected
     -- value; re-apply now to reflect the auto-detected reading order.
     self.view.inverse_reading_order = not BD.mirroredUILayout()
-    self.view:setupTouchZones()
+    self.view:refreshPageTurnInput()
     self:_syncProgressBar()
     Notification:notify(_("RTL page order detected – switching automatically."))
 end

--- a/frontend/apps/reader/modules/readerpaging.lua
+++ b/frontend/apps/reader/modules/readerpaging.lua
@@ -52,10 +52,13 @@ end
 function ReaderPaging:onGesture() end
 
 function ReaderPaging:registerKeyEvents()
+    local inverse = self.view and self.view.inverse_reading_order or false
     local prev_key, next_key = "Left", "Right"
-    if BD.mirroredUILayout() then
+    if BD.mirroredUILayout() ~= inverse then
         next_key, prev_key = prev_key, next_key
     end
+    logger.dbg("ReaderPaging: page-turn arrow keys", "previous", prev_key,
+        "next", next_key, "inverse", inverse)
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextPage = { { { "RPgFwd", "LPgFwd", next_key, " " } }, event = "GotoViewRel", args = 1, }
@@ -90,6 +93,10 @@ ReaderPaging.onPhysicalKeyboardConnected = ReaderPaging.registerKeyEvents
 
 function ReaderPaging:onReaderReady()
     self:setupTouchZones()
+    -- Reading order is loaded after init(), and may also be supplied by
+    -- metadata auto-detection. Rebuild the spatial arrow-key bindings now
+    -- that the final direction is known.
+    self:registerKeyEvents()
      -- Statistics plugin updates the footer later, if enabled
     if not (self.ui.statistics and self.ui.statistics.settings.is_enabled) then
         self.view.footer:onUpdateFooter()

--- a/frontend/apps/reader/modules/readerrolling.lua
+++ b/frontend/apps/reader/modules/readerrolling.lua
@@ -121,6 +121,8 @@ function ReaderRolling:registerKeyEvents()
     if BD.mirroredUILayout() ~= inverse then
         next_key, prev_key = prev_key, next_key
     end
+    logger.dbg("ReaderRolling: page-turn arrow keys", "previous", prev_key,
+        "next", next_key, "inverse", inverse)
     if Device:hasDPad() and Device:useDPadAsActionKeys() then
         if G_reader_settings:isTrue("left_right_keys_turn_pages") then
             self.key_events.GotoNextView = { { { "LPgFwd", next_key } }, event = "GotoViewRel", args = 1, }

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1404,6 +1404,10 @@ function ReaderView:setupTouchZones()
 end
 
 function ReaderView:onToggleReadingOrder(toggle)
+    -- Unlike inverse_reading_order itself (which is serialized for every
+    -- document), this marker records an actual per-document user decision.
+    -- Automatic metadata detection must never overwrite that decision.
+    self.ui.doc_settings:makeTrue("page_direction_user_override")
     if toggle == nil then
         toggle = not self.inverse_reading_order
     end

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1403,6 +1403,12 @@ function ReaderView:setupTouchZones()
     (self.ui.rolling or self.ui.paging):setupTouchZones()
 end
 
+function ReaderView:refreshPageTurnInput()
+    local navigator = self.ui.rolling or self.ui.paging
+    navigator:setupTouchZones()
+    navigator:registerKeyEvents()
+end
+
 function ReaderView:onToggleReadingOrder(toggle)
     -- Unlike inverse_reading_order itself (which is serialized for every
     -- document), this marker records an actual per-document user decision.
@@ -1416,7 +1422,7 @@ function ReaderView:onToggleReadingOrder(toggle)
         -- User made an explicit choice: it is no longer a vertical-rl forced value,
         -- so persist it from now on (see ReaderView:onSaveSettings).
         self.inverse_reading_order_forced = false
-        self:setupTouchZones()
+        self:refreshPageTurnInput()
         local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout() -- mirrored reading
         Notification:notify(is_rtl and _("RTL page turning.") or _("LTR page turning."))
         -- Keep progress bar direction in sync with reading order.

--- a/frontend/util/page_direction.lua
+++ b/frontend/util/page_direction.lua
@@ -4,7 +4,8 @@ Page progression direction detector for automatic RTL/LTR reading order.
 Supports:
 - EPUB: reads `page-progression-direction` from OPF spine directly via the
   ZIP archive (bypasses crengine cache entirely — reliable on first open)
-- CBZ/CBR/CBT: reads `<ReadingDirection>` from ComicInfo.xml inside the archive
+- CBZ/CBR/CBT: reads the standard `<Manga>YesAndRightToLeft</Manga>` value
+  from ComicInfo.xml, with `<ReadingDirection>` accepted for compatibility
 
 Both formats are handled via ffi/archiver (libarchive), so no C++ changes
 are required and the detection is cache-independent.
@@ -25,26 +26,67 @@ end
 
 -- ── ComicInfo.xml (CBZ/CBR) ──────────────────────────────────────────────
 
-local function parseComicInfo(xml)
+local function elementValue(xml, name)
+    -- ComicInfo normally has unprefixed elements under a root carrying xmlns
+    -- declarations. Also accept explicitly prefixed elements and attributes,
+    -- while avoiding similarly named elements such as <MangaFoo>.
+    local boundary = "%f[%s>/]"
+    local value = xml:match("<%s*" .. name .. boundary .. "[^>]*>(.-)</%s*" .. name .. "%s*>")
+    if not value then
+        value = xml:match("<%s*[%w_.-]+:" .. name .. boundary
+            .. "[^>]*>(.-)</%s*[%w_.-]+:" .. name .. "%s*>")
+    end
+    return value
+end
+
+local function canonicalValue(value)
+    if not value then return nil end
+    -- Enum values are ASCII. Ignoring separators makes the compatibility
+    -- field tolerant of the forms found in existing comic libraries.
+    return value:lower():gsub("[%s_-]", "")
+end
+
+function M.parseComicInfo(xml)
     if not xml then return nil end
-    local dir = xml:match("<ReadingDirection>%s*(%a+)%s*</ReadingDirection>")
-    return dir and (dir:upper() == "RTL" and "rtl" or "ltr") or nil
+    xml = xml:gsub("^\239\187\191", "", 1)
+             :gsub("<!%-%-.-%-%->", "")
+
+    -- ComicInfo 1.x/2.x defines this as the RTL-reading manga value. It is
+    -- authoritative when present; the non-RTL Manga enum values do not by
+    -- themselves specify a page direction.
+    local manga = canonicalValue(elementValue(xml, "Manga"))
+    if manga == "yesandrighttoleft" then
+        return "rtl"
+    end
+
+    -- ReadingDirection is not part of the core ComicInfo schema, but is used
+    -- by some producers and by older versions of this fork.
+    local direction = canonicalValue(elementValue(xml, "ReadingDirection"))
+    if direction == "rtl" or direction == "righttoleft" then
+        return "rtl"
+    elseif direction == "ltr" or direction == "lefttoright" then
+        return "ltr"
+    end
+    return nil
 end
 
 local function directionFromComicInfo(filepath)
     local reader = openArchiveReader(filepath)
     if not reader then return nil end
     local direction
+    local comicinfo_path
     for entry in reader:iterate() do
         if entry.mode == "file" then
             local lp = entry.path:lower()
             if lp == "comicinfo.xml" or lp:match("/comicinfo%.xml$") then
-                direction = parseComicInfo(reader:extractToMemory(entry.path))
+                comicinfo_path = entry.path
+                direction = M.parseComicInfo(reader:extractToMemory(entry.path))
                 break
             end
         end
     end
     reader:close()
+    logger.dbg("PageDirection: ComicInfo", filepath, comicinfo_path, "→", direction)
     return direction
 end
 

--- a/spec/unit/page_direction_spec.lua
+++ b/spec/unit/page_direction_spec.lua
@@ -1,0 +1,82 @@
+describe("Page direction metadata detector", function()
+    local PageDirection
+
+    setup(function()
+        require("commonrequire")
+        PageDirection = require("util/page_direction")
+    end)
+
+    describe("ComicInfo.xml", function()
+        it("finds and parses ComicInfo.xml inside a CBZ archive", function()
+            local Archiver = require("ffi/archiver")
+            local cbz_path = os.tmpname() .. ".cbz"
+            finally(function() os.remove(cbz_path) end)
+
+            local writer = Archiver.Writer:new()
+            assert.is_true(writer:open(cbz_path, "zip"))
+            assert.is_true(writer:addFileFromMemory("metadata/ComicInfo.xml", [[
+                <ComicInfo><Manga>YesAndRightToLeft</Manga></ComicInfo>
+            ]]))
+            assert.is_true(writer:addFileFromMemory("001.jpg", "not-an-image"))
+            writer:close()
+
+            assert.equals("rtl", PageDirection.getDirection({ file = cbz_path }))
+        end)
+
+        it("detects the standard right-to-left Manga enum", function()
+            assert.equals("rtl", PageDirection.parseComicInfo([[
+                <?xml version="1.0"?>
+                <ComicInfo xmlns="http://example.invalid/comicinfo">
+                    <Manga>YesAndRightToLeft</Manga>
+                </ComicInfo>
+            ]]))
+        end)
+
+        it("accepts namespaced elements, attributes, comments and a BOM", function()
+            assert.equals("rtl", PageDirection.parseComicInfo("\239\187\191" .. [[
+                <ci:ComicInfo xmlns:ci="urn:comicinfo">
+                    <!-- <ci:Manga>No</ci:Manga> -->
+                    <ci:Manga source="tagger"> YesAndRightToLeft </ci:Manga>
+                </ci:ComicInfo>
+            ]]))
+        end)
+
+        it("does not infer direction from the other standard Manga values", function()
+            for _, value in ipairs({ "Unknown", "No", "Yes" }) do
+                assert.is_nil(PageDirection.parseComicInfo(
+                    "<ComicInfo><Manga>" .. value .. "</Manga></ComicInfo>"))
+            end
+        end)
+
+        it("accepts legacy and descriptive ReadingDirection values", function()
+            for _, value in ipairs({ "RTL", "rtl", "RightToLeft", "right-to-left", "right_to_left" }) do
+                assert.equals("rtl", PageDirection.parseComicInfo(
+                    "<ComicInfo><ReadingDirection>" .. value
+                    .. "</ReadingDirection></ComicInfo>"))
+            end
+            for _, value in ipairs({ "LTR", "LeftToRight", "left-to-right" }) do
+                assert.equals("ltr", PageDirection.parseComicInfo(
+                    "<ComicInfo><ReadingDirection>" .. value
+                    .. "</ReadingDirection></ComicInfo>"))
+            end
+        end)
+
+        it("prefers the standard RTL Manga value over a conflicting extension", function()
+            assert.equals("rtl", PageDirection.parseComicInfo([[
+                <ComicInfo>
+                    <Manga>YesAndRightToLeft</Manga>
+                    <ReadingDirection>LTR</ReadingDirection>
+                </ComicInfo>
+            ]]))
+        end)
+
+        it("returns unknown for missing, malformed and unsupported values", function()
+            assert.is_nil(PageDirection.parseComicInfo(nil))
+            assert.is_nil(PageDirection.parseComicInfo("<ComicInfo/>"))
+            assert.is_nil(PageDirection.parseComicInfo(
+                "<ComicInfo><MangaFoo>YesAndRightToLeft</MangaFoo></ComicInfo>"))
+            assert.is_nil(PageDirection.parseComicInfo(
+                "<ComicInfo><ReadingDirection>sideways</ReadingDirection></ComicInfo>"))
+        end)
+    end)
+end)

--- a/spec/unit/reader_auto_direction_spec.lua
+++ b/spec/unit/reader_auto_direction_spec.lua
@@ -1,0 +1,112 @@
+describe("Reader auto page direction", function()
+    local Notification, PageDirection, ReaderAutoDirection
+
+    local function makeConfig(values)
+        local config = { values = values or {} }
+        function config:has(name)
+            return self.values[name] ~= nil
+        end
+        function config:readSetting(name)
+            return self.values[name]
+        end
+        function config:saveSetting(name, value)
+            self.values[name] = value
+        end
+        return config
+    end
+
+    local function makeDetector(inverse_reading_order)
+        local view = {
+            inverse_reading_order = inverse_reading_order or false,
+            setup_calls = 0,
+            sync_calls = 0,
+        }
+        function view:setupTouchZones()
+            self.setup_calls = self.setup_calls + 1
+        end
+        function view:syncProgressBarDirection()
+            self.sync_calls = self.sync_calls + 1
+        end
+        return ReaderAutoDirection:new{
+            document = { file = "book.cbz" },
+            view = view,
+        }, view
+    end
+
+    setup(function()
+        require("commonrequire")
+        Notification = require("ui/widget/notification")
+        PageDirection = require("util/page_direction")
+        ReaderAutoDirection = require("apps/reader/modules/reader_auto_direction")
+    end)
+
+    before_each(function()
+        stub(Notification, "notify")
+    end)
+
+    it("applies and versions a newly detected RTL direction", function()
+        stub(PageDirection, "getDirection").returns("rtl")
+        local detector, view = makeDetector(false)
+        local config = makeConfig()
+
+        detector:onReadSettings(config)
+
+        assert.is_true(view.inverse_reading_order)
+        assert.equals(1, view.setup_calls)
+        assert.equals(1, view.sync_calls)
+        assert.equals("rtl", config.values.direction_auto_detected)
+        assert.equals(ReaderAutoDirection.DETECTION_VERSION,
+            config.values.direction_auto_detected_version)
+    end)
+
+    it("rechecks a legacy none result with the corrected detector", function()
+        stub(PageDirection, "getDirection").returns("rtl")
+        local detector, view = makeDetector(false)
+        local config = makeConfig({ direction_auto_detected = "none" })
+
+        detector:onReadSettings(config)
+
+        assert.is_true(view.inverse_reading_order)
+        assert.equals("rtl", config.values.direction_auto_detected)
+        assert.equals(ReaderAutoDirection.DETECTION_VERSION,
+            config.values.direction_auto_detected_version)
+    end)
+
+    it("does not rescan a result from the current detector", function()
+        stub(PageDirection, "getDirection")
+        local detector = makeDetector(false)
+        local config = makeConfig({
+            direction_auto_detected = "none",
+            direction_auto_detected_version = ReaderAutoDirection.DETECTION_VERSION,
+        })
+
+        detector:onReadSettings(config)
+
+        assert.stub(PageDirection.getDirection).was_not_called()
+    end)
+
+    it("preserves a per-document direction that predates auto-detection", function()
+        stub(PageDirection, "getDirection")
+        local detector = makeDetector(false)
+        local config = makeConfig({ inverse_reading_order = false })
+
+        detector:onReadSettings(config)
+
+        assert.stub(PageDirection.getDirection).was_not_called()
+        assert.is_nil(config.values.direction_auto_detected_version)
+    end)
+
+    it("versions an unknown result without changing the page direction", function()
+        stub(PageDirection, "getDirection").returns(nil)
+        local detector, view = makeDetector(false)
+        local config = makeConfig()
+
+        detector:onReadSettings(config)
+
+        assert.is_false(view.inverse_reading_order)
+        assert.equals(0, view.setup_calls)
+        assert.equals("none", config.values.direction_auto_detected)
+        assert.equals(ReaderAutoDirection.DETECTION_VERSION,
+            config.values.direction_auto_detected_version)
+    end)
+end)

--- a/spec/unit/reader_auto_direction_spec.lua
+++ b/spec/unit/reader_auto_direction_spec.lua
@@ -27,7 +27,7 @@ describe("Reader auto page direction", function()
             setup_calls = 0,
             sync_calls = 0,
         }
-        function view:setupTouchZones()
+        function view:refreshPageTurnInput()
             self.setup_calls = self.setup_calls + 1
         end
         function view:syncProgressBarDirection()
@@ -124,7 +124,10 @@ describe("Reader auto page direction", function()
         local view = {
             inverse_reading_order = false,
             ui = { doc_settings = config },
-            setupTouchZones = function() end,
+            refresh_calls = 0,
+            refreshPageTurnInput = function(self)
+                self.refresh_calls = self.refresh_calls + 1
+            end,
             syncProgressBarDirection = function() end,
         }
 
@@ -132,6 +135,7 @@ describe("Reader auto page direction", function()
 
         assert.is_true(config.values.page_direction_user_override)
         assert.is_true(view.inverse_reading_order)
+        assert.equals(1, view.refresh_calls)
     end)
 
     it("versions an unknown result without changing the page direction", function()

--- a/spec/unit/reader_auto_direction_spec.lua
+++ b/spec/unit/reader_auto_direction_spec.lua
@@ -9,8 +9,14 @@ describe("Reader auto page direction", function()
         function config:readSetting(name)
             return self.values[name]
         end
+        function config:isTrue(name)
+            return self.values[name] == true
+        end
         function config:saveSetting(name, value)
             self.values[name] = value
+        end
+        function config:makeTrue(name)
+            self.values[name] = true
         end
         return config
     end
@@ -85,15 +91,47 @@ describe("Reader auto page direction", function()
         assert.stub(PageDirection.getDirection).was_not_called()
     end)
 
-    it("preserves a per-document direction that predates auto-detection", function()
-        stub(PageDirection, "getDirection")
-        local detector = makeDetector(false)
+    it("does not mistake an automatically serialized LTR default for a user override", function()
+        stub(PageDirection, "getDirection").returns("rtl")
+        local detector, view = makeDetector(false)
         local config = makeConfig({ inverse_reading_order = false })
 
         detector:onReadSettings(config)
 
+        assert.stub(PageDirection.getDirection).was_called(1)
+        assert.is_true(view.inverse_reading_order)
+        assert.equals("rtl", config.values.direction_auto_detected)
+    end)
+
+    it("preserves an explicit per-document reading-order override", function()
+        stub(PageDirection, "getDirection")
+        local detector, view = makeDetector(false)
+        local config = makeConfig({
+            inverse_reading_order = false,
+            page_direction_user_override = true,
+        })
+
+        detector:onReadSettings(config)
+
         assert.stub(PageDirection.getDirection).was_not_called()
+        assert.is_false(view.inverse_reading_order)
         assert.is_nil(config.values.direction_auto_detected_version)
+    end)
+
+    it("marks reading-order toggles as explicit user overrides", function()
+        local ReaderView = require("apps/reader/modules/readerview")
+        local config = makeConfig()
+        local view = {
+            inverse_reading_order = false,
+            ui = { doc_settings = config },
+            setupTouchZones = function() end,
+            syncProgressBarDirection = function() end,
+        }
+
+        ReaderView.onToggleReadingOrder(view, true)
+
+        assert.is_true(config.values.page_direction_user_override)
+        assert.is_true(view.inverse_reading_order)
     end)
 
     it("versions an unknown result without changing the page direction", function()

--- a/spec/unit/readerpaging_spec.lua
+++ b/spec/unit/readerpaging_spec.lua
@@ -1,11 +1,12 @@
 describe("Readerpaging module", function()
     local sample_pdf = "spec/front/unit/data/sample.pdf"
-    local readerui, Event, DocumentRegistry, ReaderUI, Screen
+    local readerui, BD, Event, DocumentRegistry, ReaderUI, Screen
     local paging
 
     setup(function()
         require("commonrequire")
         disable_plugins()
+        BD = require("ui/bidi")
         Event = require("ui/event")
         DocumentRegistry = require("document/documentregistry")
         ReaderUI = require("apps/reader/readerui")
@@ -36,6 +37,32 @@ describe("Readerpaging module", function()
             paging:onGotoViewRel(1)
             assert.is.truthy(called)
             readerui.onEndOfBook = nil
+        end)
+
+        it("should bind spatial arrow keys to the RTL page direction", function()
+            paging.view.inverse_reading_order = true
+            paging:registerKeyEvents()
+
+            local next_keys = paging.key_events.GotoNextPage[1][1]
+            local prev_keys = paging.key_events.GotoPrevPage[1][1]
+            local expected_next = BD.mirroredUILayout() and "Right" or "Left"
+            local expected_prev = BD.mirroredUILayout() and "Left" or "Right"
+
+            assert.is_truthy(require("util").arrayContains(next_keys, expected_next))
+            assert.is_truthy(require("util").arrayContains(prev_keys, expected_prev))
+        end)
+
+        it("should retain the spatial LTR arrow-key direction", function()
+            paging.view.inverse_reading_order = false
+            paging:registerKeyEvents()
+
+            local next_keys = paging.key_events.GotoNextPage[1][1]
+            local prev_keys = paging.key_events.GotoPrevPage[1][1]
+            local expected_next = BD.mirroredUILayout() and "Left" or "Right"
+            local expected_prev = BD.mirroredUILayout() and "Right" or "Left"
+
+            assert.is_truthy(require("util").arrayContains(next_keys, expected_next))
+            assert.is_truthy(require("util").arrayContains(prev_keys, expected_prev))
         end)
     end)
 


### PR DESCRIPTION
## Summary

- detect RTL comic page order from the standard ComicInfo `Manga` enum
- retain compatibility with existing `ReadingDirection` metadata
- version automatic direction detection so documents missed by the old detector are checked again once
- preserve explicit per-document reading-order choices

## Root cause

The previous detector only recognized the non-standard `<ReadingDirection>RTL</ReadingDirection>` form. ComicInfo 1.x/2.x represents right-to-left manga as `<Manga>YesAndRightToLeft</Manga>`, so conforming CBZ/CBR archives were left undetected. The old `direction_auto_detected` marker then cached that missed result indefinitely.

Additionally, KOReader serializes `inverse_reading_order` for every document, including an untouched default `false`. Treating the mere presence of that key as a manual override caused metadata detection to stop before reading ComicInfo.

## Implementation

- parse the standard `Manga` enum, including namespaced elements, attributes, BOMs, comments, and nested `ComicInfo.xml` paths
- accept `RTL`, `RightToLeft`, and corresponding LTR compatibility values without treating malformed values as LTR
- make the standard RTL value authoritative if compatibility metadata conflicts
- add a detection version that migrates legacy results once
- record a dedicated marker when the user changes page order, so actual overrides are preserved without confusing automatically serialized defaults for user choices
- rebuild spatial Left/Right key bindings after the final page direction is known; logical PageForward/PageBack bindings remain unchanged
- add debug logs for metadata results and every automatic-detection skip condition

## Validation

- `nix develop --no-write-lock-file -c ./kodev test front --busted spec/front/unit/page_direction_spec.lua spec/front/unit/reader_auto_direction_spec.lua spec/front/unit/readerpaging_spec.lua` — 20 tests passed
- `nix develop --no-write-lock-file -c luacheck frontend/util/page_direction.lua frontend/apps/reader/modules/reader_auto_direction.lua spec/unit/page_direction_spec.lua spec/unit/reader_auto_direction_spec.lua` — 0 warnings, 0 errors
- emulator build succeeded through the flake development shell
- Kindle PW 12th `kindlehf` cross-build succeeded
- parsing and Lua loading verified with the Kindle runtime
- the real Ghost in the Shell CBZ was verified with an existing serialized LTR default: logs show `PageDirection: ComicInfo ... → rtl`, and the sidecar is updated to `inverse_reading_order = true`
- the same CBZ verifies the post-load key map as `previous Right next Left inverse true`; taps and swipes already consume the live reading direction
