### PR TITLE
Pass quoted paths through koreader-run

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,22 @@
           exec make -C base "$@"
         '';
         koreaderRun = pkgs.writeShellScriptBin "koreader-run" ''
-          exec make run "$@"
+          make
+
+          install_dir="$(
+            make -s --no-print-directory \
+              PHONY+=__print_install_dir \
+              --eval='__print_install_dir:;@printf "%s\\n" "$(INSTALL_DIR)"' \
+              __print_install_dir
+          )"
+          cd "$install_dir/koreader"
+
+          while true; do
+            status=0
+            ./luajit reader.lua "$@" || status=$?
+            [ "$status" -eq 85 ] || exit "$status"
+            set --
+          done
         '';
         koreaderTestBase = pkgs.writeShellScriptBin "koreader-test-base" ''
           exec base/test-runner/runtests "$@"


### PR DESCRIPTION
## Summary

- build the emulator before launching it from the Nix helper
- invoke `reader.lua` directly so file paths stay as individual shell arguments
- retain KOReader restart exit-code handling without reusing the initial document argument

## Validation

- launched the real CBZ path containing spaces, parentheses, brackets, and Japanese characters through `nix develop --no-write-lock-file -c koreader-run ...`
- KOReader logged the complete expected path in `opening file`
- no shell syntax error occurred