### PR TITLE
Fix vertical cross-page highlight endpoint

### DIFF
--- a/frontend/apps/reader/modules/readerhighlight.lua
+++ b/frontend/apps/reader/modules/readerhighlight.lua
@@ -954,6 +954,7 @@ function ReaderHighlight:clear(clear_id)
     end
     self.is_word_selection = false
     self.selected_text_start_xpointer = nil
+    self.selected_text_start_word_end_xpointer = nil
     if self.hold_pos then
         self.hold_pos = nil
         self.selected_text = nil
@@ -1752,6 +1753,7 @@ function ReaderHighlight:onHold(arg, ges)
             -- a marker when back from across-pages text selection, which
             -- is handled in onHoldPan()
             self.selected_text_start_xpointer = word.pos0
+            self.selected_text_start_word_end_xpointer = word.pos1
         end
         return true
     end
@@ -1957,7 +1959,8 @@ function ReaderHighlight:onHoldPan(_, ges)
         end
     end
 
-    local old_text = self.selected_text and self.selected_text.text
+    local old_selection = self.selected_text
+    local old_text = old_selection and old_selection.text
     -- For vertical-rl rolling documents, native crengine selection draws
     -- per-word boxes (scattered) rather than column-spanning boxes.
     -- Use Lua-side drawing via view.highlight.temp for cleaner appearance.
@@ -1977,6 +1980,7 @@ function ReaderHighlight:onHoldPan(_, ges)
             -- and spans quite some height, the marker could point away
             -- from the start position)
             self.selected_text_start_xpointer = self.selected_text.pos0
+            self.selected_text_start_word_end_xpointer = self.selected_text.pos1
         end
     end
 
@@ -1987,23 +1991,37 @@ function ReaderHighlight:onHoldPan(_, ges)
     -- a range bounded by current-page positions only, losing the multi-page
     -- extent.  Re-anchor the selection start with the original press
     -- xpointer (still tracked in self.selected_text_start_xpointer) and
-    -- recompute text + sboxes from that anchor to the finger end.
+    -- recompute text + sboxes from that anchor to the finger end.  We must
+    -- resolve the finger end independently: getTextFromPositions() orders its
+    -- two results, so its pos1 may belong to the stale hold_pos rather than to
+    -- the current finger position.  Using that ordered pos1 made it impossible
+    -- to shorten the selection beyond that stale position on the new page.
     if is_vertical and self.ui.rolling and self.restore_page_mode_func
-            and self.selected_text and self.selected_text.pos1
             and self.selected_text_start_xpointer then
         local sx = self.selected_text_start_xpointer
-        local cur = self.selected_text.pos1
-        if sx ~= cur then
+        local finger_word = self.ui.document:getWordFromPosition(self.holdpan_pos, true)
+        if finger_word and finger_word.pos0 and finger_word.pos1 then
             local pos0, pos1
-            if self.ui.document:compareXPointers(sx, cur) == 1 then
-                pos0, pos1 = sx, cur   -- sx precedes cur in doc order
-            else
-                pos0, pos1 = cur, sx
+            local order = self.ui.document:compareXPointers(sx, finger_word.pos1)
+            if order == 1 then
+                -- The finger is after the initial word in document order.
+                pos0, pos1 = sx, finger_word.pos1
+            elseif order then
+                -- The finger is before the initial word.  Keep the complete
+                -- initial word selected just as an ordinary drag does.
+                pos0 = finger_word.pos0
+                pos1 = self.selected_text_start_word_end_xpointer or sx
             end
-            self.selected_text.pos0 = pos0
-            self.selected_text.pos1 = pos1
-            self.selected_text.text  = self.ui.document:getTextFromXPointers(pos0, pos1, true)
-            self.selected_text.sboxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true)
+            if pos0 and pos1 then
+                self.selected_text = self.selected_text or {}
+                self.selected_text.pos0 = pos0
+                self.selected_text.pos1 = pos1
+                self.selected_text.text  = self.ui.document:getTextFromXPointers(pos0, pos1, true)
+                self.selected_text.sboxes = self.ui.document:getScreenBoxesFromPositions(pos0, pos1, true)
+            end
+        elseif old_selection then
+            -- Keep the last valid cross-page range while crossing whitespace.
+            self.selected_text = old_selection
         end
     end
 

--- a/spec/unit/vertical_text_spec.lua
+++ b/spec/unit/vertical_text_spec.lua
@@ -522,6 +522,64 @@ describe("Vertical text", function()
                     "Diagonal sboxes span only %dpx (min_x=%d max_x=%d) — expected ≥%dpx for multi-column drag",
                     max_x - min_x, min_x, max_x, math.floor(w * 0.3)))
         end)
+
+        it("cross-page drag can shrink to the start of the next page", function()
+            local w, h = Screen:getWidth(), Screen:getHeight()
+            local start_x, start_y, start_word = find_any_content(doc)
+            assert.truthy(start_word, "No source word found on the first page")
+
+            readerui.highlight:onHold(nil, {
+                pos = Geom:new{ x = start_x, y = start_y },
+            })
+            local source_xpointer = readerui.highlight.selected_text_start_xpointer
+            assert.truthy(source_xpointer, "Initial selection xpointer was not retained")
+
+            -- Leave the corner first to arm corner scrolling, then enter the
+            -- vertical-rl next-page corner while keeping the hold active.
+            readerui.highlight:onHoldPan(nil, {
+                pos = Geom:new{ x = start_x, y = start_y },
+            })
+            local first_page = doc:getCurrentPage(true)
+            readerui.highlight:onHoldPan(nil, {
+                pos = Geom:new{ x = 1, y = h - 1 },
+            })
+            fastforward_ui_events()
+            assert.equals(first_page + 1, doc:getCurrentPage(true),
+                "Bottom-left hold-pan did not turn to the next page")
+
+            -- Find the earliest visible word by scanning in vertical-rl
+            -- document order: rightmost columns first, then top to bottom.
+            local end_x, end_y, end_word
+            for x = w - 10, 10, -10 do
+                for y = 10, math.floor(h * 0.35), 10 do
+                    local page_pos = readerui.view:screenToPageTransform(
+                        Geom:new{ x = x, y = y })
+                    local word = page_pos and doc:getWordFromPosition(page_pos, true)
+                    local sbox = word and word.sbox
+                    if word and word.word and word.pos1 and sbox
+                            and sbox.x <= x and x <= sbox.x + sbox.w
+                            and sbox.y <= y and y <= sbox.y + sbox.h then
+                        end_x, end_y, end_word = x, y, word
+                        break
+                    end
+                end
+                if end_word then break end
+            end
+            assert.truthy(end_word, "No word found near the start of the next page")
+
+            local next_page = doc:getCurrentPage(true)
+            readerui.highlight:onHoldPan(nil, {
+                pos = Geom:new{ x = end_x, y = end_y },
+            })
+            assert.equals(next_page, doc:getCurrentPage(true),
+                "Dragging to next-page text was mistaken for a previous-page corner")
+            local selected = readerui.highlight.selected_text
+            assert.truthy(selected and selected.pos0 and selected.pos1)
+            assert.equals(0, doc:compareXPointers(selected.pos0, source_xpointer),
+                "Cross-page selection lost its original anchor")
+            assert.equals(0, doc:compareXPointers(selected.pos1, end_word.pos1),
+                "Cross-page selection endpoint did not follow the finger")
+        end)
     end)
 
     -----------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Resolve the cross-page vertical highlight endpoint from the current finger position instead of the ordered `pos1` returned from a stale, off-screen hold position.
- Preserve both boundaries of the initially selected word so backward selections retain the full anchor word.
- Keep the last valid cross-page selection while the finger crosses whitespace.
- Add a regression test that turns to the next vertical page and shrinks the selection to the earliest visible text.

## Why

After a vertical-rl corner page turn, the original hold position is no longer visible. `getTextFromPositions()` orders its two endpoints, so its `pos1` was not necessarily the endpoint under the finger. This prevented users from shrinking a cross-page highlight beyond roughly the first few lines of the next page.

## User impact

A continuous hold-and-drag selection can now span a page boundary and be reduced all the way to the beginning of the next page.

## Validation

- Vertical text and reader highlight suites: 43/43 tests passed.
- Targeted cross-page regression test passed.
- `git diff --check` passed.
- Manually confirmed by the reporter with the affected vertical EPUB workflow.