### PR TITLE
Fix EPUB engine build and nightly versioning

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
         # Shared across all build/publish jobs so the embedded git-rev and the
         # OTA zsync Filename header agree. Otherwise OTAManager parses two
         # different version strings and offers an update on every check.
-        run: echo "nightly_version=v$(date -u +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
+        run: echo "nightly_version=v$(date -u +%Y.%m.%d)-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
 
   kindle:
     name: Kindle


### PR DESCRIPTION
## Summary

- Update koreader-base to the merged crengine fix so `libkoreader-cre.so` includes all fork-specific sources.
- Add the GitHub run number to nightly versions (`vYYYY.MM.DD-RUN`) so a same-day rebuild is a newer OTA version instead of being treated as the existing build.

## Root cause

The crengine CMake migration omitted two fork-specific source files. Its shared Lua module then failed to load with unresolved internal symbols, preventing EPUB files from opening on all platforms.

## Validation

- Rebuilt the SDL emulator
- Opened standard and vertical-ruby EPUB fixtures: 11 tests passed

Depends on merged m-tky/crengine#11 and m-tky/koreader-base#8.