### PR TITLE
ota: publish kotasync assets

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,6 +94,7 @@ jobs:
           path: |
             koreader-kindle-latest-nightly.zip
             koreader-kindle-latest-nightly.targz
+            koreader-*.tar.xz
 
   kindlehf:
     name: Kindle (HF)
@@ -126,6 +127,7 @@ jobs:
           path: |
             koreader-kindlehf-latest-nightly.zip
             koreader-kindlehf-latest-nightly.targz
+            koreader-*.tar.xz
 
   kindlepw2:
     name: Kindle (PW2/non-HF)
@@ -158,6 +160,7 @@ jobs:
           path: |
             koreader-kindlepw2-latest-nightly.zip
             koreader-kindlepw2-latest-nightly.targz
+            koreader-*.tar.xz
 
   kobo:
     name: Kobo
@@ -190,6 +193,7 @@ jobs:
           path: |
             koreader-kobo-latest-nightly.zip
             koreader-kobo-latest-nightly.targz
+            koreader-*.tar.xz
 
   pocketbook:
     name: PocketBook
@@ -222,6 +226,7 @@ jobs:
           path: |
             koreader-pocketbook-latest-nightly.zip
             koreader-pocketbook-latest-nightly.targz
+            koreader-*.tar.xz
 
   cervantes:
     name: Cervantes
@@ -254,6 +259,7 @@ jobs:
           path: |
             koreader-cervantes-latest-nightly.zip
             koreader-cervantes-latest-nightly.targz
+            koreader-*.tar.xz
 
   remarkable:
     name: reMarkable (armhf)
@@ -286,6 +292,7 @@ jobs:
           path: |
             koreader-remarkable-latest-nightly.zip
             koreader-remarkable-latest-nightly.targz
+            koreader-*.tar.xz
 
   remarkable-aarch64:
     name: reMarkable (aarch64)
@@ -318,6 +325,7 @@ jobs:
           path: |
             koreader-remarkable-aarch64-latest-nightly.zip
             koreader-remarkable-aarch64-latest-nightly.targz
+            koreader-*.tar.xz
 
   android-arm:
     name: Android (ARM)
@@ -469,6 +477,24 @@ jobs:
           # Versioned zsync copies
           for f in artifacts/**/*-latest-nightly.zsync; do
             cp "$f" "${f/latest-nightly/$VER}"
+          done
+
+      - name: Build kotasync manifest tool
+        run: |
+          make -C base/kotasync appdir
+          echo "KOTASYNC=$(find "$PWD/base/build" -path '*/AppDir/AppRun' -type f -print -quit)" >> "$GITHUB_ENV"
+
+      - name: Generate kotasync files
+        run: |
+          set -euo pipefail
+          VER=$NIGHTLY_VERSION
+          shopt -s globstar
+          cp "artifacts/kobo/koreader-kobo-$VER.tar.xz" "artifacts/kobo/koreader-kobov5-$VER.tar.xz"
+          cp "artifacts/kindle/koreader-kindle-$VER.tar.xz" "artifacts/kindle/koreader-kindle-legacy-$VER.tar.xz"
+          for package in artifacts/**/*.tar.xz; do
+            name=$(basename "$package")
+            latest_name="${name/$VER/latest-nightly}"
+            "$KOTASYNC" make "$package" "$(dirname "$package")/${latest_name%.tar.xz}.kotasync"
           done
 
       - name: List artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,7 @@ jobs:
           path: |
             koreader-kindle-latest-stable.zip
             koreader-kindle-latest-stable.targz
+            koreader-*.tar.xz
 
   kindlehf:
     name: Kindle (HF)
@@ -84,6 +85,7 @@ jobs:
           path: |
             koreader-kindlehf-latest-stable.zip
             koreader-kindlehf-latest-stable.targz
+            koreader-*.tar.xz
 
   kindlepw2:
     name: Kindle (PW2/non-HF)
@@ -114,6 +116,7 @@ jobs:
           path: |
             koreader-kindlepw2-latest-stable.zip
             koreader-kindlepw2-latest-stable.targz
+            koreader-*.tar.xz
 
   kobo:
     name: Kobo
@@ -144,6 +147,7 @@ jobs:
           path: |
             koreader-kobo-latest-stable.zip
             koreader-kobo-latest-stable.targz
+            koreader-*.tar.xz
 
   pocketbook:
     name: PocketBook
@@ -174,6 +178,7 @@ jobs:
           path: |
             koreader-pocketbook-latest-stable.zip
             koreader-pocketbook-latest-stable.targz
+            koreader-*.tar.xz
 
   cervantes:
     name: Cervantes
@@ -204,6 +209,7 @@ jobs:
           path: |
             koreader-cervantes-latest-stable.zip
             koreader-cervantes-latest-stable.targz
+            koreader-*.tar.xz
 
   remarkable:
     name: reMarkable (armhf)
@@ -234,6 +240,7 @@ jobs:
           path: |
             koreader-remarkable-latest-stable.zip
             koreader-remarkable-latest-stable.targz
+            koreader-*.tar.xz
 
   remarkable-aarch64:
     name: reMarkable (aarch64)
@@ -264,6 +271,7 @@ jobs:
           path: |
             koreader-remarkable-aarch64-latest-stable.zip
             koreader-remarkable-aarch64-latest-stable.targz
+            koreader-*.tar.xz
 
   android-arm:
     name: Android (ARM)
@@ -417,6 +425,24 @@ jobs:
           # Versioned zsync copies
           for f in artifacts/**/*-latest-stable.zsync; do
             cp "$f" "${f/latest-stable/$TAG}"
+          done
+
+      - name: Build kotasync manifest tool
+        run: |
+          make -C base/kotasync appdir
+          echo "KOTASYNC=$(find "$PWD/base/build" -path '*/AppDir/AppRun' -type f -print -quit)" >> "$GITHUB_ENV"
+
+      - name: Generate kotasync files
+        run: |
+          set -euo pipefail
+          TAG=$RELEASE_TAG
+          shopt -s globstar
+          cp "artifacts/kobo/koreader-kobo-$TAG.tar.xz" "artifacts/kobo/koreader-kobov5-$TAG.tar.xz"
+          cp "artifacts/kindle/koreader-kindle-$TAG.tar.xz" "artifacts/kindle/koreader-kindle-legacy-$TAG.tar.xz"
+          for package in artifacts/**/*.tar.xz; do
+            name=$(basename "$package")
+            latest_name="${name/$TAG/latest-stable}"
+            "$KOTASYNC" make "$package" "$(dirname "$package")/${latest_name%.tar.xz}.kotasync"
           done
 
       - name: List artifacts

--- a/frontend/ui/otamanager.lua
+++ b/frontend/ui/otamanager.lua
@@ -26,6 +26,8 @@ local OTAManager = {
     -- NOTE: Each URL *MUST* end with a /
     -- Keyed by channel name; getOTAServer() auto-selects based on getOTAChannel().
     ota_servers = {
+        -- kotasync and the legacy zsync manifests are co-published here so
+        -- builds using either updater can keep updating without a migration.
         stable  = "https://github.com/m-tky/koreader-tategumi/releases/latest/download/",
         nightly = "https://github.com/m-tky/koreader-tategumi/releases/download/nightly/",
     },


### PR DESCRIPTION
## What changed

- Publish kotasync manifests and versioned tar.xz packages alongside normal release assets.
- Keep the existing OTA URLs so already-installed v2026.08.05 builds can update without a manual migration.
- Continue publishing zsync/targz assets for older installations.

## Why

v2026.08.05 uses the upstream kotasync client while the release workflows only published zsync manifests, producing HTTP 404 during OTA checks.

## Compatibility

Both updater generations use the same normal release endpoint. A rolling nightly replaces its assets on each run, so the additional OTA artifacts remain bounded at two per OTA model.

## Validation

- `luacheck frontend/ui/otamanager.lua`
- YAML parse and `actionlint` for both workflows
- Built `base/kotasync` locally and generated a manifest from a real `mkrelease.sh` tar.xz archive.