### PR TITLE
ci: fetch kotasync source before publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -422,6 +422,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fetch kotasync source
+        run: git submodule update --init --recursive base
+
       - name: Set nightly version (YYYY.MM.DD)
         # Use the version computed in check-changes so we agree with what the
         # build jobs embedded via RELEASE_TAG (otherwise OTA Filename and the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,6 +362,9 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
           fetch-depth: 0
 
+      - name: Fetch kotasync source
+        run: git submodule update --init --recursive base
+
       - name: Determine tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Fix

Initialize the `base` submodule in the nightly and release publish jobs before building the kotasync manifest tool.

## Root cause

The platform build jobs succeeded, but the publish job only checked out the superproject. `base/kotasync` was therefore absent and `make -C base/kotasync appdir` failed.

## Validation

- Parsed both workflow YAML files
- Ran `actionlint` (only pre-existing informational shellcheck notices)
- Reviewed the failing publish-job log from nightly run #31017648055.