### PR TITLE
ci: install Meson for kotasync publishing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -484,6 +484,9 @@ jobs:
 
       - name: Build kotasync manifest tool
         run: |
+          # kotasync shares KOReader's third-party build setup, which requires
+          # Meson even though the resulting AppRun is only used for manifests.
+          sudo apt-get update -qq && sudo apt-get install -y meson
           make -C base/kotasync appdir
           echo "KOTASYNC=$(find "$PWD/base/build" -path '*/AppDir/AppRun' -type f -print -quit)" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
The nightly publish runner builds kotasync to generate OTA manifests. Install its required Meson build tool before invoking make.