### PR TITLE
Support logical CSS decorations in vertical writing

### DIFF
--- a/spec/unit/vertical_inline_insets_spec.lua
+++ b/spec/unit/vertical_inline_insets_spec.lua
@@ -1,0 +1,69 @@
+--[[--
+Vertical text: logical inline insets.
+
+In vertical-rl the inline axis runs from physical top to bottom, so logical
+inline margins, padding and borders must reserve space before and after an
+inline element.
+--]]
+
+describe("Vertical text: logical inline insets #vertical_inline_insets", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local path = "/tmp/koreader_vertical_inline_insets.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function find_word(doc, target)
+        local found
+        for x = Screen:getWidth() - 3, 3, -3 do
+            for y = 3, Screen:getHeight() - 3, 3 do
+                local word = doc:getWordFromPosition({ x = x, y = y })
+                if word and word.word == target and word.sbox then
+                    found = word.sbox
+                end
+            end
+        end
+        return assert(found, target .. " was not rendered")
+    end
+
+    it("maps logical margins, padding and borders onto the vertical inline axis", function()
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body, p { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 32px; line-height: 1; }
+span { margin-inline-start: 1em; margin-inline-end: 1em;
+       padding-inline-start: 0.5em; padding-inline-end: 0.5em;
+       border-inline: 4px solid; }
+</style></head><body><p>甲<span>乙</span>丙</p></body></html>]])
+        f:close()
+
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(path),
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local first = find_word(readerui.document, "甲")
+        local middle = find_word(readerui.document, "乙")
+        local last = find_word(readerui.document, "丙")
+        local before = middle.y - (first.y + first.h)
+        local after = last.y - (middle.y + middle.h)
+        print(string.format("[vertical_inline_insets] before=%d after=%d", before, after))
+        assert.is_true(before >= 40, "logical inline-start inset did not reserve vertical space")
+        assert.is_true(after >= 40, "logical inline-end inset did not reserve vertical space")
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)

--- a/spec/unit/vertical_logical_sizes_spec.lua
+++ b/spec/unit/vertical_logical_sizes_spec.lua
@@ -1,0 +1,56 @@
+--[[--
+Logical sizing maps to CSS's physical height in vertical-rl: inline-size
+limits top-to-bottom line advance, while block-size limits right-to-left
+column advance.
+--]]
+
+describe("Vertical text: logical sizes #vertical_logical_sizes", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local path = "/tmp/koreader_vertical_logical_sizes.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function find_word(doc, target)
+        for x = Screen:getWidth() - 3, 3, -3 do
+            for y = 3, Screen:getHeight() - 3, 3 do
+                local word = doc:getWordFromPosition({ x = x, y = y })
+                if word and word.word == target and word.sbox then return word.sbox end
+            end
+        end
+        error(target .. " was not rendered")
+    end
+
+    it("uses inline-size as the top-to-bottom available text length", function()
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body, p { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 32px; line-height: 1; }
+table { inline-size: 96px; border-spacing: 0; }
+td { padding: 0; }
+</style></head><body><table><tr><td>甲</td><td>乙</td></tr></table></body></html>]])
+        f:close()
+        readerui = ReaderUI:new{ dimen = Screen:getSize(), document = DocumentRegistry:openDocument(path) }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local a, b = find_word(readerui.document, "甲"), find_word(readerui.document, "乙")
+        local inline_extent = (b.y + b.h) - a.y
+        assert.is_true(a.y < b.y, "inline-size table columns did not advance top-to-bottom")
+        assert.is_true(inline_extent <= 96,
+            string.format("inline-size was not applied to table width: %dpx", inline_extent))
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)

--- a/spec/unit/vertical_selection_inner_rect_spec.lua
+++ b/spec/unit/vertical_selection_inner_rect_spec.lua
@@ -1,0 +1,108 @@
+-- Regression coverage for selection rectangles in vertical-rl documents.
+--
+-- The deliberately asymmetric padding and border make stale physical-axis
+-- corrections visible: the word box returned by crengine and the rectangle
+-- used by the selection/highlight UI must describe the same glyph.
+
+describe("Vertical text: selection inner rectangles #vertical_selection_inner_rect", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager, Geom
+    local readerui
+    local path = "/tmp/koreader_vertical_selection_inner_rect.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+        Geom = require("ui/geometry")
+    end)
+
+    local function open_document(legacy)
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; }
+body { writing-mode: vertical-rl; font-size: 28px; line-height: 1;
+       padding: 13px 37px 29px 61px;
+       border-style: solid; border-width: 2px 7px 3px 11px; }
+p { margin: 0; }
+</style></head><body><p>選択矩形の内側補正を確認するための縦書き本文です。選択矩形の内側補正を確認するための縦書き本文です。</p></body></html>]])
+        f:close()
+        local document = DocumentRegistry:openDocument(path)
+        if legacy then
+            -- INNER_FIELDS_SET belongs to enhanced block rendering.  Force the
+            -- legacy selection/hit-test correction path for this regression.
+            document:setBlockRenderingFlags(0)
+        end
+        readerui = ReaderUI:new{
+            dimen = Screen:getSize(),
+            document = document,
+        }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        readerui.rolling:onGotoPage(1)
+        fastforward_ui_events()
+        return readerui.document
+    end
+
+    local function find_word(doc)
+        for x = Screen:getWidth() - 10, 10, -5 do
+            for y = 10, Screen:getHeight() - 10, 5 do
+                local word = doc:getWordFromPosition(Geom:new{x = x, y = y})
+                if word and word.word and word.word ~= "" and word.sbox
+                        and word.sbox.w > 0 and word.sbox.h > 0 then
+                    return word
+                end
+            end
+        end
+    end
+
+    local function center(box)
+        return box.x + math.floor(box.w / 2), box.y + math.floor(box.h / 2)
+    end
+
+    it("keeps a word xpointer selection rectangle on the glyph inner box", function()
+        local doc = open_document(true)
+        assert.is_true(doc:isVerticalText())
+        local word = assert(find_word(doc), "no word found in asymmetric vertical fixture")
+        local x, y = center(word.sbox)
+        local ok, selected = pcall(function()
+            return doc:getTextFromPositions({x = x, y = y}, {x = x, y = y})
+        end)
+        assert.is_true(ok, "getTextFromPositions failed")
+        local sb = selected and selected.sboxes and selected.sboxes[1]
+        assert.truthy(sb, "word xpointer returned no selection rectangle")
+        local sx, sy = center(sb)
+        assert.is_true(math.abs(sx - x) <= 2,
+            string.format("selection x-center drifted by %dpx", sx - x))
+        assert.is_true(math.abs(sy - y) <= 2,
+            string.format("selection y-center drifted by %dpx", sy - y))
+    end)
+
+    it("draws a hold highlight over the same inner rectangle", function()
+        local doc = open_document(true)
+        local word = assert(find_word(doc), "no word found in asymmetric vertical fixture")
+        local x, y = center(word.sbox)
+        readerui.highlight:onHold(nil, {pos = Geom:new{x = x, y = y}})
+        fastforward_ui_events()
+        local displayed
+        for _, sboxes in pairs(readerui.view.highlight.temp or {}) do
+            if sboxes and #sboxes > 0 then displayed = sboxes[1]; break end
+        end
+        assert.truthy(displayed, "hold did not produce a highlight rectangle")
+        local dx, dy = center(displayed)
+        local wx, wy = center(word.sbox)
+        assert.is_true(math.abs(dx - wx) <= 2,
+            string.format("highlight x-center drifted by %dpx", dx - wx))
+        assert.is_true(math.abs(dy - wy) <= 2,
+            string.format("highlight y-center drifted by %dpx", dy - wy))
+    end)
+
+    after_each(function()
+        if readerui then readerui:onClose(); readerui = nil end
+        UIManager:quit()
+    end)
+end)

--- a/spec/unit/vertical_table_axes_spec.lua
+++ b/spec/unit/vertical_table_axes_spec.lua
@@ -1,0 +1,183 @@
+--[[--
+Vertical table layout uses logical coordinates: columns advance on the inline
+axis (top to bottom) and rows advance on the block axis (right to left).
+--]]
+
+describe("Vertical text: table logical axes #vertical_table_axes", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local path = "/tmp/koreader_vertical_table_axes.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function find_word(doc, target)
+        local found
+        for x = Screen:getWidth() - 3, 3, -3 do
+            for y = 3, Screen:getHeight() - 3, 3 do
+                local word = doc:getWordFromPosition({ x = x, y = y })
+                if word and word.word == target and word.sbox then found = word.sbox end
+            end
+        end
+        return assert(found, target .. " was not rendered")
+    end
+
+    local function widest_rule_to_right(box)
+        local bb = Screen.bb
+        local xs = {}
+        local y0 = math.max(0, box.y - 20)
+        local y1 = math.min(Screen:getHeight() - 1, box.y + box.h + 20)
+        -- Ignore glyph strokes; the authored outer edge is well outside the
+        -- one-glyph content box in this fixed-width cell.
+        for x = box.x + box.w + 30, math.min(Screen:getWidth() - 1, box.x + box.w + 140) do
+            local dark = 0
+            for y = y0, y1 do
+                local px = bb:getPixel(x, y)
+                if px and px:getR() < 180 then dark = dark + 1 end
+            end
+            if dark >= box.h * 0.8 then xs[#xs + 1] = x end
+        end
+        local widest, run, previous = 0, 0, nil
+        for _, x in ipairs(xs) do
+            run = previous and x == previous + 1 and run + 1 or 1
+            widest = math.max(widest, run)
+            previous = x
+        end
+        return widest
+    end
+
+    it("maps columns to inline and rows to block progression", function()
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 28px; }
+p { margin: 0; }
+table { border-spacing: 0; border: 2px solid; }
+td { padding-top: .5em; padding-bottom: .5em; border: 1px solid; }
+</style></head><body><table><tr><td>甲</td><td>乙</td></tr><tr><td>丙</td><td>丁</td></tr></table></body></html>]])
+        f:close()
+        readerui = ReaderUI:new{ dimen = Screen:getSize(), document = DocumentRegistry:openDocument(path) }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local a, b = find_word(readerui.document, "甲"), find_word(readerui.document, "乙")
+        local c, d = find_word(readerui.document, "丙"), find_word(readerui.document, "丁")
+        assert.is_true(a.y < b.y, "second column did not advance down the inline axis")
+        assert.is_true(c.y < d.y, "second column in row two did not advance down the inline axis")
+        assert.is_true(c.x < a.x, "second row did not advance left on the block axis")
+        assert.is_true(d.x < b.x, "second row did not advance left on the block axis")
+    end)
+
+    it("keeps colspan on the inline axis and rowspan on the block axis", function()
+        if readerui then readerui:onClose(); readerui = nil end
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 24px; }
+table { border-spacing: 0; margin: 0 0 1em 0; }
+td { width: 3em; height: 3em; padding: 0; border: 1px solid; }
+</style></head><body>
+<table><tr><td colspan="2">甲</td><td>乙</td></tr>
+<tr><td>丙</td><td>丁</td><td>戊</td></tr></table>
+<table><tr><td rowspan="2" style="vertical-align: middle">己</td><td>庚</td></tr>
+<tr><td>辛</td></tr></table>
+</body></html>]])
+        f:close()
+        readerui = ReaderUI:new{ dimen = Screen:getSize(), document = DocumentRegistry:openDocument(path) }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local doc = readerui.document
+        local jia, yi = find_word(doc, "甲"), find_word(doc, "乙")
+        local bing, ding, wu = find_word(doc, "丙"), find_word(doc, "丁"), find_word(doc, "戊")
+        -- A colspan of two cells consumes two inline tracks: the following
+        -- cell is farther down than one ordinary cell track.
+        assert.is_true(yi.y > jia.y, "colspan did not advance on the inline axis")
+        assert.is_true(yi.y - jia.y > ding.y - bing.y,
+            "colspan did not consume two logical inline tracks")
+        assert.is_true(bing.x < jia.x and ding.x < jia.x and wu.x < jia.x,
+            "second table row did not advance left on the block axis")
+
+        local ji, geng, xin = find_word(doc, "己"), find_word(doc, "庚"), find_word(doc, "辛")
+        -- A rowspan spans rows (the block axis), so its vertically centred
+        -- glyph lies between the two row glyphs rather than below them.
+        assert.is_true(geng.x > xin.x, "rowspan rows did not advance left on the block axis")
+        assert.is_true(ji.x < geng.x and ji.x > xin.x,
+            "rowspan was laid out on the inline axis instead of the block axis")
+    end)
+
+    it("maps collapsed logical table borders to vertical-rl edges", function()
+        if readerui then readerui:onClose(); readerui = nil end
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 28px; }
+table { border-collapse: collapse; margin: 1em; }
+td { writing-mode: vertical-rl; width: 4em; height: 4em; padding: 0; border: 0; }
+td { border-block-start: 6px solid; border-inline-start: 3px solid; }
+</style></head><body><p>前</p><table><tr><td>甲</td></tr></table></body></html>]])
+        f:close()
+        readerui = ReaderUI:new{ dimen = Screen:getSize(), document = DocumentRegistry:openDocument(path) }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+
+        local box = find_word(readerui.document, "甲")
+        local bb = Screen.bb
+        local function dark(x, y)
+            local px = bb:getPixel(x, y)
+            return px and px:getR() < 180
+        end
+        local rules = {}
+        for x = math.max(0, box.x - 160), math.min(Screen:getWidth() - 1, box.x + box.w + 160) do
+            local n = 0
+            for y = math.max(0, box.y - 20), math.min(Screen:getHeight() - 1, box.y + box.h + 20) do
+                if dark(x, y) then n = n + 1 end
+            end
+            if n >= box.h * 0.8 then table.insert(rules, x) end
+        end
+        local right_rule = false
+        for _, x in ipairs(rules) do
+            if x > box.x + box.w + 8 then right_rule = true; break end
+        end
+        assert.is_true(right_rule, "collapsed border-block-start was not on the right edge")
+    end)
+
+    it("prefers a wider row border over a cell border", function()
+        if readerui then readerui:onClose(); readerui = nil end
+        local function render(cell_border)
+            local f = assert(io.open(path, "wb"))
+            f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 28px; }
+p { margin: 0; }
+table { border-collapse: collapse; margin: 1em; }
+tr { border-right: 7px solid; }
+td { width: 4em; height: 4em; padding: 0; ]] .. cell_border .. [[ }
+</style></head><body><p>前</p><table><tr><td>甲</td></tr></table></body></html>]])
+            f:close()
+            readerui = ReaderUI:new{ dimen = Screen:getSize(), document = DocumentRegistry:openDocument(path) }
+            UIManager:show(readerui)
+            fastforward_ui_events()
+            return widest_rule_to_right(find_word(readerui.document, "甲"))
+        end
+
+        local wider = render("border-right: 2px solid;")
+        assert.is_true(wider >= 3,
+            "wider row border did not win over the cell border")
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)

--- a/spec/unit/vertical_table_pagination_spec.lua
+++ b/spec/unit/vertical_table_pagination_spec.lua
@@ -1,0 +1,112 @@
+-- Regression coverage for a tall vertical-rl table.  A row-spanning cell must
+-- be emitted once and must not overlap the words in the other table rows.
+
+describe("Vertical text: tall table rowspan #vertical_table_pagination", function()
+    local DocumentRegistry, ReaderUI, Screen, UIManager
+    local readerui
+    local path = "/tmp/koreader_vertical_table_pagination.xhtml"
+
+    setup(function()
+        require("commonrequire")
+        disable_plugins()
+        require("document/canvascontext"):init(require("device"))
+        DocumentRegistry = require("document/documentregistry")
+        ReaderUI = require("apps/reader/readerui")
+        Screen = require("device").screen
+        UIManager = require("ui/uimanager")
+    end)
+
+    local function write_fixture()
+        local f = assert(io.open(path, "wb"))
+        f:write([[<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><head><style>
+html, body { margin: 0; padding: 0; }
+body { writing-mode: vertical-rl; font-size: 24px; line-height: 1; }
+table { border-collapse: collapse; margin: 0; }
+td { width: 5em; height: 5em; padding: 0; border: 1px solid; }
+</style></head><body><table>
+<tr><td rowspan="12">標</td><td>ROW_01</td></tr>
+<tr><td>ROW_02</td></tr>
+<tr><td>ROW_03</td></tr>
+<tr><td>ROW_04</td></tr>
+<tr><td>ROW_05</td></tr>
+<tr><td>ROW_06</td></tr>
+<tr><td>ROW_07</td></tr>
+<tr><td>ROW_08</td></tr>
+<tr><td>ROW_09</td></tr>
+<tr><td>ROW_10</td></tr>
+<tr><td>ROW_11</td></tr>
+<tr><td>ROW_12</td></tr>
+<tr><td>ROW_13</td><td>ROW_14</td></tr>
+<tr><td>ROW_15</td><td>ROW_16</td></tr>
+<tr><td>ROW_25</td><td>ROW_26</td></tr>
+<tr><td>ROW_27</td><td>ROW_28</td></tr>
+<tr><td>ROW_29</td><td>ROW_30</td></tr>
+<tr><td>ROW_31</td><td>ROW_32</td></tr>
+<tr><td>ROW_33</td><td>ROW_34</td></tr>
+<tr><td>ROW_35</td><td>ROW_36</td></tr>
+</table></body></html>]])
+        f:close()
+    end
+
+    local function collect_words(doc)
+        local found = {}
+        local step_x = math.max(4, math.floor(Screen:getWidth() / 80))
+        local step_y = math.max(4, math.floor(Screen:getHeight() / 100))
+        for x = 2, Screen:getWidth() - 2, step_x do
+            for y = 2, Screen:getHeight() - 2, step_y do
+                local ok, word = pcall(doc.getWordFromPosition, doc, { x = x, y = y })
+                if ok and word and word.word and word.sbox and #word.word > 0 then
+                    local sb = word.sbox
+                    local key = string.format("%s:%d:%d:%d:%d", word.word,
+                        sb.x, sb.y, sb.w, sb.h)
+                    found[key] = { text = word.word, sbox = sb }
+                end
+            end
+        end
+        return found
+    end
+
+    it("does not duplicate or overlap the rowspan word", function()
+        write_fixture()
+        readerui = ReaderUI:new{ dimen = Screen:getSize(),
+            document = DocumentRegistry:openDocument(path) }
+        UIManager:show(readerui)
+        fastforward_ui_events()
+        local doc = readerui.document
+        local sentinel = {}
+        local page_boxes = {}
+        local words = collect_words(doc)
+        local boxes = {}
+        for _, item in pairs(words) do
+            boxes[#boxes + 1] = item.sbox
+            if item.text == "標" then
+                sentinel[#sentinel + 1] = item.sbox
+            end
+        end
+        page_boxes[#page_boxes + 1] = boxes
+
+        assert.is_true(#sentinel >= 1, "rowspan cell was not reachable in the table layout")
+
+        -- Distinct table words must not occupy the same rectangle after a
+        -- table is laid out.  Ignore tiny edge contact from glyph metrics.
+        for _, boxes in ipairs(page_boxes) do
+            for i = 1, #boxes do
+                for j = i + 1, #boxes do
+                    local a, b = boxes[i], boxes[j]
+                    local overlap_w = math.min(a.x + a.w, b.x + b.w) - math.max(a.x, b.x)
+                    local overlap_h = math.min(a.y + a.h, b.y + b.h) - math.max(a.y, b.y)
+                    if overlap_w > 2 and overlap_h > 2 then
+                        local overlap = overlap_w * overlap_h
+                        assert.is_true(overlap < math.min(a.w * a.h, b.w * b.h) * 0.2,
+                            "table words have materially overlapping sboxes")
+                    end
+                end
+            end
+        end
+    end)
+
+    teardown(function()
+        if readerui then readerui:onClose() end
+    end)
+end)


### PR DESCRIPTION
## Summary
- add writing-mode-aware logical CSS insets, sizes, and border shorthands
- correct legacy selection and hit-test geometry
- improve vertical table border-collapse ownership and conflict handling
- add vertical regression coverage for insets, logical sizes, selections, and tables

## Verification
- KOReader dev shell ready.
  koreader-build          — build emulator (make -C base)
  koreader-run            — run emulator (make run)
  koreader-test-base      — run base/ unit tests
  koreader-test-front     — run frontend unit tests
  koreader-test-vertical  — run vertical text screenshot tests
  koreader-create-epub    — create test EPUB fixture

Before first test run, install Lua test rocks:
  nix develop .#setup-luarocks
ninja: Jobserver mode detected:  -j12 --jobserver-auth=fifo:/home/user/.local/state/codex-desktop/tmp/nix-shell.JnhtkE/GMfifo447319 -- VERBOSE= KODEBUG=1 TARGET=
   0% | Building 'crengine'
ninja: Jobserver mode detected:  -j12 --jobserver-auth=fifo:/home/user/.local/state/codex-desktop/tmp/nix-shell.JnhtkE/GMfifo447319 -- VERBOSE= KODEBUG=1 TARGET=
ninja: no work to do.
  50% | Installing 'crengine'
  50% | Building 'koreader'
ninja: Jobserver mode detected:  -j12 --jobserver-auth=fifo:/home/user/.local/state/codex-desktop/tmp/nix-shell.JnhtkE/GMfifo447319 -- VERBOSE= KODEBUG=1 TARGET=
ninja: no work to do.
 100% | Installing 'koreader'
[*] Install front spec only for the emulator
[*] Install launcher for the emulator
[*] Install update once marker
[*] Install plugins
[*] Install resources
[*] Install data files
- targeted vertical CSS/table specs