### PR TITLE
Fix RTL document navigation widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ use Android's APK install flow instead; the APKs published by this fork's GitHub
 releases support the same in-app update check, download the next APK in-app, and
 then hand it to Android's installer.
 
+### Fonts for Japanese vertical text
+
+For correct vertical punctuation and symbols, select a Japanese font with the
+OpenType `vert` and `vrt2` features—`vrt2` is especially important for some
+composite vertical glyphs. Fonts without these vertical substitutions can leave
+brackets, quotation marks, dashes, and other symbols in horizontal forms.
+**Noto Sans CJK JP** and **Noto Serif CJK JP** are suitable examples; add one
+through KOReader's font settings and select it as the document font.
+
 ### Kindle: install with KPM
 
 On a Kindle with the Kindle Package Manager (KPM), add this fork's repository once:
@@ -229,6 +238,14 @@ Kindle、Kobo、PocketBook、Cervantes、reMarkable 版は KOReader のファイ
 Android APK 版は Android の APK インストール機能を使います。本フォークの GitHub
 リリースで配布している APK では、同じアプリ内の更新確認から次の APK を検出・
 ダウンロードし、Android のインストーラに渡して更新できます。
+
+### 日本語縦書き用フォント
+
+縦書きの約物・記号を正しく表示するには、OpenType の `vert` と `vrt2` 機能を
+持つ日本語フォントを選んでください。特に `vrt2` は一部の複合縦組み字形に必要です。
+これらの縦組み字形に未対応のフォントでは、括弧・引用符・ダッシュなどが横書き用の
+字形のまま表示されることがあります。**Noto Sans CJK JP** や **Noto Serif CJK JP**
+が適しています。KOReader のフォント設定から追加し、文書フォントとして選択してください。
 
 ### Kindle: KPM を使ったインストール
 

--- a/frontend/apps/reader/modules/readerfooter.lua
+++ b/frontend/apps/reader/modules/readerfooter.lua
@@ -2515,8 +2515,10 @@ function ReaderFooter:TapFooter(ges)
         local dimen = self.progress_bar.dimen
         -- if reader footer is not drawn before the dimen value should be nil
         if dimen then
-            local percentage = (pos.x - dimen.x)/dimen.w
-            self.ui:handleEvent(Event:new("GotoPercentage", percentage))
+            local percentage = self.progress_bar:getPercentageFromPosition(pos)
+            if percentage then
+                self.ui:handleEvent(Event:new("GotoPercentage", percentage))
+            end
         end
         self:onUpdateFooter(true)
         return true

--- a/frontend/apps/reader/modules/readerview.lua
+++ b/frontend/apps/reader/modules/readerview.lua
@@ -1039,19 +1039,19 @@ function ReaderView:shouldInvertBiDiLayoutMirroring()
     return self.invert_ui_layout
 end
 
--- Single source of truth for the footer progress-bar fill direction.
--- The bar is inverted (fills right→left, TOC ticks mirrored) when the UI layout
--- is mirrored, when RTL reading order is active, or when the document is
--- vertical-rl (page 1 = rightmost).  All call sites (onReadSettings, the two
--- toggles, ReaderAutoDirection, and the footer's own setup) funnel through here
--- so they cannot disagree (e.g. toggling reading order no longer wipes the
--- vertical-rl inversion).
-function ReaderView:syncProgressBarDirection()
-    if not self.footer then return end
+-- Whether document navigation UI should put page 1 on the right. This combines
+-- the manual layout setting with the document's reading order and vertical-rl
+-- layout, so the footer, skim dialog, thumbnail grid, and book map agree.
+function ReaderView:shouldInvertPageProgression()
     local is_rtl = self.inverse_reading_order ~= BD.mirroredUILayout()
     local is_vertical = self.document and self.document.isVerticalText
                         and self.document:isVerticalText()
-    self.footer:invertProgressBar(self.invert_ui_layout or is_rtl or is_vertical)
+    return self.invert_ui_layout or is_rtl or is_vertical
+end
+
+function ReaderView:syncProgressBarDirection()
+    if not self.footer then return end
+    self.footer:invertProgressBar(self:shouldInvertPageProgression())
 end
 
 function ReaderView:onToggleUILayoutMiroring(toggle)

--- a/frontend/ui/widget/bookmapwidget.lua
+++ b/frontend/ui/widget/bookmapwidget.lua
@@ -694,10 +694,7 @@ function BookMapWidget:init()
     -- so we should avoid allocating memory to huge data structures.
     self.enable_focus_navigation = not Device:isTouchDevice() and Device:hasDPad() and Device:useDPadAsActionKeys()
 
-    -- For vertical-rl documents, mirror the map so page progression runs
-    -- right-to-left (page 1 at the right), matching the reading direction.
-    if self.ui.view:shouldInvertBiDiLayoutMirroring()
-            or (self.ui.document.isVerticalText and self.ui.document:isVerticalText()) then
+    if self.ui.view:shouldInvertPageProgression() then
         BD.invert()
     end
 

--- a/frontend/ui/widget/pagebrowserwidget.lua
+++ b/frontend/ui/widget/pagebrowserwidget.lua
@@ -46,10 +46,7 @@ local PageBrowserWidget = FocusManager:extend{
 function PageBrowserWidget:init()
     self.layout = {}
     self.build_focus_layout = not Device:isTouchDevice() and Device:hasDPad() and Device:useDPadAsActionKeys()
-    -- For vertical-rl documents, mirror the thumbnail grid so page progression
-    -- runs right-to-left (page 1 at the right), matching the reading direction.
-    if self.ui.view:shouldInvertBiDiLayoutMirroring()
-            or (self.ui.document.isVerticalText and self.ui.document:isVerticalText()) then
+    if self.ui.view:shouldInvertPageProgression() then
         BD.invert()
     end
 

--- a/frontend/ui/widget/skimtowidget.lua
+++ b/frontend/ui/widget/skimtowidget.lua
@@ -81,12 +81,9 @@ function SkimToWidget:init()
     self.curr_page = self.ui:getCurrentPage()
     self.page_count = self.ui.document:getPageCount()
 
-    -- Determine if we need to invert the button functionality and labels.
-    -- For vertical-rl documents, also invert so the progress bar fills from the
-    -- right and prev/next buttons match right-to-left reading (page 1 = rightmost),
-    -- mirroring the footer progress bar inversion in ReaderFooter:onReaderReady.
-    local invert_buttons = self.ui.view:shouldInvertBiDiLayoutMirroring()
-        or (self.ui.document.isVerticalText and self.ui.document:isVerticalText())
+    -- Keep the skim UI in step with the footer: its progress bar and navigation
+    -- controls must follow the document's page progression.
+    local invert_buttons = self.ui.view:shouldInvertPageProgression()
 
     self.progress_bar = ProgressWidget:new{
         width = inner_width,

--- a/spec/unit/reader_auto_direction_spec.lua
+++ b/spec/unit/reader_auto_direction_spec.lua
@@ -1,5 +1,5 @@
 describe("Reader auto page direction", function()
-    local Notification, PageDirection, ReaderAutoDirection
+    local BD, Notification, PageDirection, ReaderAutoDirection
 
     local function makeConfig(values)
         local config = { values = values or {} }
@@ -41,6 +41,7 @@ describe("Reader auto page direction", function()
 
     setup(function()
         require("commonrequire")
+        BD = require("ui/bidi")
         Notification = require("ui/widget/notification")
         PageDirection = require("util/page_direction")
         ReaderAutoDirection = require("apps/reader/modules/reader_auto_direction")
@@ -136,6 +137,23 @@ describe("Reader auto page direction", function()
         assert.is_true(config.values.page_direction_user_override)
         assert.is_true(view.inverse_reading_order)
         assert.equals(1, view.refresh_calls)
+    end)
+
+    it("uses the reading order for document page progression", function()
+        local ReaderView = require("apps/reader/modules/readerview")
+        stub(BD, "mirroredUILayout").returns(false)
+        local view = {
+            inverse_reading_order = false,
+            invert_ui_layout = false,
+            document = {
+                isVerticalText = function() return false end,
+            },
+        }
+
+        assert.is_false(ReaderView.shouldInvertPageProgression(view))
+
+        view.inverse_reading_order = true
+        assert.is_true(ReaderView.shouldInvertPageProgression(view))
     end)
 
     it("versions an unknown result without changing the page direction", function()


### PR DESCRIPTION
## Summary
- use one page-progression direction predicate for the footer, skim dialog, page browser, and book map
- make footer taps honor the displayed progress-bar direction
- cover RTL reading-order progression with a unit test

## Validation
- diff whitespace check passed
- Lua syntax compilation passed for all modified Lua files
- unit-test execution is unavailable locally because the environment lacks make and Busted