### PR TITLE
font: add vertical font diagnosis

### DIFF
--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -64,6 +64,14 @@ function ReaderFont:setupFaceMenuTable()
         sub_item_table_func = function() return self:getFontFamiliesTable() end,
         separator = true,
     })
+    table.insert(self.face_table, {
+        text = _("Diagnose vertical font"),
+        callback = function()
+            self:showVerticalFontDiagnostic()
+        end,
+        keep_menu_open = true,
+        separator = true,
+    })
     -- Font list
     cre = require("document/credocument"):engineInit()
     local face_list = cre.getFontFaces()
@@ -81,15 +89,6 @@ function ReaderFont:setupFaceMenuTable()
         if not font_filename then
             -- The font may be available only in italic, for example script/cursive fonts
             font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v, nil, true)
-        end
-        local function hasMissingVerticalMetrics()
-            if not self.ui.document:isVerticalText() or not font_filename or not font_faceindex then
-                return false
-            end
-            -- nil means a font whose metadata could not be inspected. Do not
-            -- turn that uncertainty into a warning.
-            local face_info = FontList:getFaceInfo(font_filename, font_faceindex)
-            return face_info and face_info.has_vertical_metrics == false
         end
         table.insert(self.face_table, {
             text_func = function()
@@ -115,11 +114,6 @@ function ReaderFont:setupFaceMenuTable()
                 end
                 if newly_added_fonts[v] then
                     text = text .. "  \u{EA93}" -- "NEW" in a black square, from nerdfont
-                end
-                if hasMissingVerticalMetrics() then
-                    -- This face remains selectable: CRengine falls back to horizontal
-                    -- metrics, but vertical punctuation and alignment may be degraded.
-                    text = text .. "  [" .. _("no vertical metrics") .. "]"
                 end
                 return text
             end,
@@ -159,6 +153,63 @@ function ReaderFont:setupFaceMenuTable()
     -- Have TouchMenu show half of the usual nb of items, so we
     -- have more room to see how the text looks with that font
     self.face_table.max_per_page = 5
+end
+
+function ReaderFont:showVerticalFontDiagnostic()
+    cre = cre or require("document/credocument"):engineInit()
+    local font_filename, font_faceindex = cre.getFontFaceFilenameAndFaceIndex(self.font_face)
+    if not font_filename then
+        font_filename, font_faceindex = cre.getFontFaceFilenameAndFaceIndex(self.font_face, nil, true)
+    end
+    local font_name = self.font_face
+    if font_filename and font_faceindex then
+        font_name = FontList:getLocalizedFontName(font_filename, font_faceindex) or font_name
+    end
+
+    local lines = {
+        _("Vertical font diagnosis"),
+        "",
+        T(_("Selected font: %1"), BD.wrap(font_name)),
+        "",
+    }
+    local face_info = font_filename and font_faceindex
+        and FontList:getFaceInfo(font_filename, font_faceindex)
+    if not face_info then
+        table.insert(lines, _("The selected font could not be inspected."))
+    else
+        if face_info.has_vertical_metrics == true then
+            table.insert(lines, _("Vertical metrics: available."))
+        elseif face_info.has_vertical_metrics == false then
+            table.insert(lines, _("Vertical metrics: not available."))
+        else
+            table.insert(lines, _("Vertical metrics could not be inspected."))
+        end
+
+        if face_info.has_vert_gsub == true and face_info.has_vrt2_gsub == true then
+            table.insert(lines, _("Vertical glyph forms: available."))
+        elseif face_info.has_vert_gsub == false and face_info.has_vrt2_gsub == false then
+            table.insert(lines, _("Vertical glyph forms: not available."))
+        elseif face_info.has_vert_gsub == nil or face_info.has_vrt2_gsub == nil then
+            table.insert(lines, _("Vertical glyph forms could not be inspected."))
+        else
+            table.insert(lines, _("Vertical glyph forms: partially available."))
+        end
+
+        if face_info.has_vertical_metrics == false
+                or (face_info.has_vert_gsub == false and face_info.has_vrt2_gsub == false) then
+            table.insert(lines, "")
+            table.insert(lines, _("This font can still be used. If punctuation or brackets look incorrect, try another font."))
+        end
+    end
+
+    local embedded_fonts = self.ui.document:getEmbeddedFontList()
+    if embedded_fonts and next(embedded_fonts) ~= nil then
+        table.insert(lines, "")
+        table.insert(lines, _("The book provides embedded fonts. This diagnosis covers the selected font; text may still use a different font."))
+    end
+    UIManager:show(InfoMessage:new{
+        text = table.concat(lines, "\n"),
+    })
 end
 
 function ReaderFont:onGesture() end

--- a/frontend/apps/reader/modules/readerfont.lua
+++ b/frontend/apps/reader/modules/readerfont.lua
@@ -82,6 +82,15 @@ function ReaderFont:setupFaceMenuTable()
             -- The font may be available only in italic, for example script/cursive fonts
             font_filename, font_faceindex, is_monospace = cre.getFontFaceFilenameAndFaceIndex(v, nil, true)
         end
+        local function hasMissingVerticalMetrics()
+            if not self.ui.document:isVerticalText() or not font_filename or not font_faceindex then
+                return false
+            end
+            -- nil means a font whose metadata could not be inspected. Do not
+            -- turn that uncertainty into a warning.
+            local face_info = FontList:getFaceInfo(font_filename, font_faceindex)
+            return face_info and face_info.has_vertical_metrics == false
+        end
         table.insert(self.face_table, {
             text_func = function()
                 -- defaults are hardcoded in credocument.lua
@@ -106,6 +115,11 @@ function ReaderFont:setupFaceMenuTable()
                 end
                 if newly_added_fonts[v] then
                     text = text .. "  \u{EA93}" -- "NEW" in a black square, from nerdfont
+                end
+                if hasMissingVerticalMetrics() then
+                    -- This face remains selectable: CRengine falls back to horizontal
+                    -- metrics, but vertical punctuation and alignment may be degraded.
+                    text = text .. "  [" .. _("no vertical metrics") .. "]"
                 end
                 return text
             end,

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -120,6 +120,7 @@ local function collectFaceInfo(path)
             local hbface = HB.hb_ft_face_create_referenced(ftsize.face)
             fres.names = hbface:getNames()
             fres.scripts, fres.langs = hbface:getCoverage()
+            fres.has_vert_gsub, fres.has_vrt2_gsub = hbface:hasVerticalFeatures()
             fres.path = path
             fres.index = i
             table.insert(res, fres)
@@ -152,12 +153,14 @@ function FontList:_readList(dir, mark)
         -- And into cached info table
         mark[path] = true
         if self.fontinfo[path] and (self.fontinfo[path].change == attr.change) then
-            -- `has_vertical_metrics` was added after fontinfo.dat had already
+            -- Capability fields were added after fontinfo.dat had already
             -- shipped. Reprobe old entries once so a stale cache is not
             -- mistaken for an inspected font with unknown capabilities.
             local has_capabilities = true
             for _, face in ipairs(self.fontinfo[path]) do
-                if face.has_vertical_metrics == nil then
+                if face.has_vertical_metrics == nil
+                        or face.has_vert_gsub == nil
+                        or face.has_vrt2_gsub == nil then
                     has_capabilities = false
                     break
                 end

--- a/frontend/fontlist.lua
+++ b/frontend/fontlist.lua
@@ -152,7 +152,19 @@ function FontList:_readList(dir, mark)
         -- And into cached info table
         mark[path] = true
         if self.fontinfo[path] and (self.fontinfo[path].change == attr.change) then
-            return
+            -- `has_vertical_metrics` was added after fontinfo.dat had already
+            -- shipped. Reprobe old entries once so a stale cache is not
+            -- mistaken for an inspected font with unknown capabilities.
+            local has_capabilities = true
+            for _, face in ipairs(self.fontinfo[path]) do
+                if face.has_vertical_metrics == nil then
+                    has_capabilities = false
+                    break
+                end
+            end
+            if has_capabilities then
+                return
+            end
         end
         local fi = collectFaceInfo(path)
         if not fi or not next(fi) then return end
@@ -261,6 +273,14 @@ function FontList:getLocalizedFontName(file, index)
     altname = altname and (altname[tonumber(HB.HB_OT_NAME_ID_FULL_NAME)] or altname[tonumber(HB.HB_OT_NAME_ID_FONT_FAMILY)])
     if not altname then return end -- ensure nil
     return altname
+end
+
+-- Returns cached metadata for one face. Keep this access behind FontList so
+-- callers do not depend on the on-disk cache's path/index layout.
+function FontList:getFaceInfo(file, index)
+    self:getFontList()
+    local faces = self.fontinfo[file]
+    return faces and faces[index + 1]
 end
 
 function FontList:getFontArgFunc()


### PR DESCRIPTION
Replace noisy per-font warnings with an on-demand diagnosis in the Font menu. It reports vertical metrics and optional OpenType GSUB vert/vrt2 capability, keeps fonts selectable, and explains embedded-font ambiguity. Depends on m-tky/koreader-base#15 and koreader/koreader-translations#176.