### PR TITLE
ci: use sync token for pull requests

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Report unresolved conflicts
         if: steps.merge.outputs.unresolved != ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}
         run: |
           gh issue create \
             --title "Upstream sync requires resolution ($(date -u +%F))" \
@@ -89,7 +89,9 @@ jobs:
       - name: Push candidate and create or update pull request
         if: steps.merge.outputs.unresolved == ''
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Repository GITHUB_TOKENs may be barred from creating pull requests.
+          # Use the configured PAT for both the push and PR API when available.
+          GH_TOKEN: ${{ secrets.UPSTREAM_SYNC_TOKEN || github.token }}
           BRANCH: upstream-sync/master
         run: |
           if git diff --quiet origin/master...HEAD; then


### PR DESCRIPTION
Use UPSTREAM_SYNC_TOKEN for gh issue/PR operations. The failed run pushed its candidate branch successfully, then the repository GITHUB_TOKEN was denied while creating the PR.